### PR TITLE
Upgrade to ludwig-ui ^1.0.1 since 1.0.0 is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "express": "~4.12.0",
     "morgan": "~1.5.0",
     "prerender-node": "^1.1.1",
-    "ludwig-ui": "^1.0.0",
+    "ludwig-ui": "^1.0.1",
     "sgmap-mes-aides-api": "sgmap/mes-aides-api#v0.1.2",
     "serve-favicon": "~2.2.0"
   },


### PR DESCRIPTION
To ensure that 1.0.0 will never be installed.