### PR TITLE
Amélioration de la gestion des dates

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -5,9 +5,10 @@ var ddsApp = angular.module('ddsApp', ['ui.router', 'ngAnimate', 'ui.bootstrap',
 ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $uiViewScrollProvider) {
     moment.lang('fr');
 
-    moment.parseTwoDigitYear = function(input) {
+    var CURRENT_YEAR_TWO_DIGITS = (new Date()).getFullYear() - 2000;
+    moment.parseTwoDigitYear = function(input) {  // see https://github.com/moment/moment/issues/2219
         input = parseInt(input);
-        return (input > 19 ? 1900 : 2000) + input;
+        return input + (input <= CURRENT_YEAR_TWO_DIGITS ? 2000 : 1900);
     };
 
     $locationProvider.html5Mode(true);

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -5,6 +5,11 @@ var ddsApp = angular.module('ddsApp', ['ui.router', 'ngAnimate', 'ui.bootstrap',
 ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $uiViewScrollProvider) {
     moment.lang('fr');
 
+    moment.parseTwoDigitYear = function(input) {
+        input = parseInt(input);
+        return (input > 19 ? 1900 : 2000) + input;
+    };
+
     $locationProvider.html5Mode(true);
     $urlRouterProvider.otherwise('/');
     $uiViewScrollProvider.useAnchorScroll();

--- a/app/js/controllers/foyer/individuForm.js
+++ b/app/js/controllers/foyer/individuForm.js
@@ -4,6 +4,8 @@ angular.module('ddsApp').controller('FoyerIndividuFormCtrl', function($scope, op
     $scope.statutsSpecifiques = IndividuService.getStatutsSpecifiques();
 
     options.minAge = 0;
+    options.maxAge = 130;
+
     if ('enfant' === options.individuRole) {
         options.maxAge = 25;
         options.formPersonneACharge = true;

--- a/app/js/directives/date.js
+++ b/app/js/directives/date.js
@@ -12,8 +12,10 @@ angular.module('ddsApp').directive('ddsDate', function() {
                 return result;
             });
 
-            ctrl.$formatters.push(function(birthDateMoment) {
-                return birthDateMoment.format('DD/MM/YYYY');
+            ctrl.$formatters.push(function(momentInstance) {
+                if (! momentInstance) return;
+
+                return momentInstance.format('DD/MM/YYYY');
             });
         }
     };

--- a/app/js/directives/date.js
+++ b/app/js/directives/date.js
@@ -4,22 +4,22 @@ angular.module('ddsApp').directive('ddsDate', function() {
     return {
         require: 'ngModel',
         link: function(scope, elm, attrs, ctrl) {
-            ctrl.$parsers.unshift(function(viewValue) {
-                if (angular.isString(viewValue) && viewValue.length > 0) {
-                    var date = moment(viewValue, 'DD/MM/YYYY', true);
-                    if (! date.isValid()) {
-                        date = moment(viewValue, 'DD/MM/YY', true);
-                    }
-                    if (!date.isValid()) {
-                        ctrl.$setValidity('ddsDate', false);
+            ctrl.$parsers.push(function(viewValue) {
+                var result = moment(viewValue, 'DD/MM/YYYY', true);
 
-                        return viewValue;
-                    }
+                if (result.isValid()) {
+                    ctrl.$setValidity('ddsDate', true);
+                    return result;
                 }
 
-                ctrl.$setValidity('ddsDate', true);
+                result = moment(viewValue, 'DD/MM/YY');
 
-                return viewValue;
+                if (result.isValid()) {
+                    ctrl.$setValidity('ddsDate', true);
+                    return result;
+                }
+
+                ctrl.$setValidity('ddsDate', false);
             });
         }
     };

--- a/app/js/directives/date.js
+++ b/app/js/directives/date.js
@@ -15,7 +15,7 @@ angular.module('ddsApp').directive('ddsDate', function() {
             ctrl.$formatters.push(function(momentInstance) {
                 if (! momentInstance) return;
 
-                return momentInstance.format('DD/MM/YYYY');
+                return momentInstance.format('L');
             });
         }
     };

--- a/app/js/directives/date.js
+++ b/app/js/directives/date.js
@@ -11,6 +11,10 @@ angular.module('ddsApp').directive('ddsDate', function() {
 
                 return result;
             });
+
+            ctrl.$formatters.push(function(birthDateMoment) {
+                return birthDateMoment.format('DD/MM/YYYY');
+            });
         }
     };
 });

--- a/app/js/directives/date.js
+++ b/app/js/directives/date.js
@@ -7,6 +7,9 @@ angular.module('ddsApp').directive('ddsDate', function() {
             ctrl.$parsers.unshift(function(viewValue) {
                 if (angular.isString(viewValue) && viewValue.length > 0) {
                     var date = moment(viewValue, 'DD/MM/YYYY', true);
+                    if (! date.isValid()) {
+                        date = moment(viewValue, 'DD/MM/YY', true);
+                    }
                     if (!date.isValid()) {
                         ctrl.$setValidity('ddsDate', false);
 

--- a/app/js/directives/date.js
+++ b/app/js/directives/date.js
@@ -5,21 +5,11 @@ angular.module('ddsApp').directive('ddsDate', function() {
         require: 'ngModel',
         link: function(scope, elm, attrs, ctrl) {
             ctrl.$parsers.push(function(viewValue) {
-                var result = moment(viewValue, 'DD/MM/YYYY', true);
+                var result = moment(viewValue, ['DD/MM/YY', 'L', 'LL']);
 
-                if (result.isValid()) {
-                    ctrl.$setValidity('ddsDate', true);
-                    return result;
-                }
+                ctrl.$setValidity('ddsDate', result.isValid());
 
-                result = moment(viewValue, 'DD/MM/YY');
-
-                if (result.isValid()) {
-                    ctrl.$setValidity('ddsDate', true);
-                    return result;
-                }
-
-                ctrl.$setValidity('ddsDate', false);
+                return result;
             });
         }
     };

--- a/app/js/directives/dateNaissanceMaxAge.js
+++ b/app/js/directives/dateNaissanceMaxAge.js
@@ -1,37 +1,16 @@
 'use strict';
 
-var dateNaissanceValidator = function(scope, ctrl, attrs, attr, isValid) {
-  ctrl.$parsers.unshift(function(viewValue) {
-      var date = moment(viewValue, 'DD/MM/YYYY', true);
-
-      if (! date.isValid()) {
-          date = moment(viewValue, 'DD/MM/YY', true);
-      }
-
-      if (date.isValid()) {
-          var ageCond = scope.$eval(attrs[attr]);
-          if (angular.isDefined(ageCond)) {
-              var years = moment().diff(date, 'years');
-              if (!isValid(years, ageCond)) {
-                  ctrl.$setValidity(attr, false);
-
-                  return viewValue;
-              }
-          }
-      }
-
-      ctrl.$setValidity(attr, true);
-
-      return viewValue;
-  });
-};
-
 angular.module('ddsApp').directive('dateNaissanceMaxAge', function() {
     return {
         require: 'ngModel',
-        link: function(scope, elm, attrs, ctrl) {
-            dateNaissanceValidator(scope, ctrl, attrs, 'dateNaissanceMaxAge', function(years, ageCond) {
-              return years <= ageCond;
+        link: function($scope, elm, attrs, ctrl) {
+            ctrl.$parsers.push(function(momentInstance) {
+                var maximum = $scope.$eval(attrs.dateNaissanceMaxAge),
+                    actual = moment().diff(momentInstance, 'years');
+
+                ctrl.$setValidity('dateNaissanceMaxAge', actual <= maximum);
+
+                return momentInstance;
             });
         }
     };
@@ -40,9 +19,14 @@ angular.module('ddsApp').directive('dateNaissanceMaxAge', function() {
 angular.module('ddsApp').directive('dateNaissanceMinAge', function() {
     return {
         require: 'ngModel',
-        link: function(scope, elm, attrs, ctrl) {
-            dateNaissanceValidator(scope, ctrl, attrs, 'dateNaissanceMinAge', function(years, ageCond) {
-              return years >= ageCond;
+        link: function($scope, elm, attrs, ctrl) {
+            ctrl.$parsers.push(function(momentInstance) {
+                var minimum = $scope.$eval(attrs.dateNaissanceMinAge),
+                    actual = moment().diff(momentInstance, 'years');
+
+                ctrl.$setValidity('dateNaissanceMinAge', actual >= minimum);
+
+                return momentInstance;
             });
         }
     };

--- a/app/js/directives/dateNaissanceMaxAge.js
+++ b/app/js/directives/dateNaissanceMaxAge.js
@@ -3,6 +3,11 @@
 var dateNaissanceValidator = function(scope, ctrl, attrs, attr, isValid) {
   ctrl.$parsers.unshift(function(viewValue) {
       var date = moment(viewValue, 'DD/MM/YYYY', true);
+
+      if (! date.isValid()) {
+          date = moment(viewValue, 'DD/MM/YY', true);
+      }
+
       if (date.isValid()) {
           var ageCond = scope.$eval(attrs[attr]);
           if (angular.isDefined(ageCond)) {

--- a/app/js/directives/recapSituation.js
+++ b/app/js/directives/recapSituation.js
@@ -59,13 +59,12 @@ angular.module('ddsRecapSituation').directive('recapSituation', function($timeou
             };
 
             var mapIndividu = function(individu) {
-                var dateDeNaissance = moment(individu.dateDeNaissance, 'MM/DD/YYYY');
                 var nationalite = _.find(nationalites, { id: individu.nationalite });
                 nationalite = nationalite ? nationalite.label : 'inconnue';
                 var target = {
                     label: individuLabel(individu),
-                    dateDeNaissance: individu.dateDeNaissance,
-                    age: moment(situation.dateDeValeur).diff(dateDeNaissance, 'years'),
+                    dateDeNaissance: individu.dateDeNaissance.format('DD/MM/YYYY'),
+                    age: moment(situation.dateDeValeur).diff(individu.dateDeNaissance, 'years'),
                     nationalite: nationalite,
                     statutsSpecifiques: IndividuService.formatStatutsSpecifiques(individu),
                     ressources: mapIndividuRessources(individu)

--- a/app/js/directives/recapSituation.js
+++ b/app/js/directives/recapSituation.js
@@ -63,7 +63,7 @@ angular.module('ddsRecapSituation').directive('recapSituation', function($timeou
                 nationalite = nationalite ? nationalite.label : 'inconnue';
                 var target = {
                     label: individuLabel(individu),
-                    dateDeNaissance: individu.dateDeNaissance.format('DD/MM/YYYY'),
+                    dateDeNaissance: individu.dateDeNaissance.format('L'),
                     age: moment(situation.dateDeValeur).diff(individu.dateDeNaissance, 'years'),
                     nationalite: nationalite,
                     statutsSpecifiques: IndividuService.formatStatutsSpecifiques(individu),

--- a/app/js/embed.js
+++ b/app/js/embed.js
@@ -14,7 +14,7 @@ app.config(function($locationProvider, $stateProvider) {
                 return $http.get('/api/situations/' + $stateParams.situationId).then(function(result) {
                     var situation = result.data;
                     situation.individus.forEach(function(individu) {
-                        individu.dateDeNaissance = moment(individu.dateDeNaissance).format('DD/MM/YYYY');
+                        individu.dateDeNaissance = moment(individu.dateDeNaissance);
                     });
                     return situation;
                 });

--- a/app/js/services/individuService.js
+++ b/app/js/services/individuService.js
@@ -5,9 +5,8 @@ angular.module('ddsCommon').service('IndividuService', function($filter, situati
 
     return {
         age: function(individu) {
-            var dateNaissance = moment(individu.dateDeNaissance, 'DD/MM/YYYY');
             // FIXME Il faudrait retourner l'âge par rapport à la date de valeur de la situation
-            return moment().diff(dateNaissance, 'years');
+            return moment().diff(individu.dateDeNaissance, 'years');
         },
 
         label: function(individu) {

--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -70,15 +70,22 @@ angular.module('ddsApp').factory('SituationService', function($http, $sessionSto
                 this.newSituation();
             }
 
+            situation.individus.forEach(function(individu) {
+                individu.dateDeNaissance = moment(individu.dateDeNaissance);
+            });
+
             return situation;
         },
 
         restoreRemote: function(situationId) {
             return $http.get('/api/situations/' + situationId).then(function(result) {
-                situation = $sessionStorage.situation = result.data;
+                situation = result.data;
+
                 situation.individus.forEach(function(individu) {
-                    individu.dateDeNaissance = moment(individu.dateDeNaissance).format('DD/MM/YYYY');
+                    individu.dateDeNaissance = moment(individu.dateDeNaissance);
                 });
+
+                $sessionStorage.situation = situation;
 
                 return situation;
             });
@@ -157,7 +164,7 @@ angular.module('ddsApp').factory('SituationService', function($http, $sessionSto
 
         createApiCompatibleIndividu: function(individu) {
             var result = _.cloneDeep(individu);
-            result.dateDeNaissance = moment(individu.dateDeNaissance, 'DD/MM/YYYY').format('YYYY-MM-DD');
+            result.dateDeNaissance = individu.dateDeNaissance.format('YYYY-MM-DD');
 
             if (individu.dateArriveeFoyerString) {
                 var dateArrivee = moment(individu.dateArriveeFoyerString, 'DD/MM/YYYY');

--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -136,7 +136,7 @@ angular.module('ddsApp').factory('SituationService', function($http, $sessionSto
             }
 
             if (situation.logement.dateArriveeString) {
-                var dateArrivee = moment(situation.logement.dateArriveeString, 'DD/MM/YYYY');
+                var dateArrivee = moment(situation.logement.dateArriveeString, 'L');
                 if (dateArrivee.isValid()) {
                     situation.logement.dateArrivee = dateArrivee.format('YYYY-MM-DD');
                 }
@@ -167,14 +167,14 @@ angular.module('ddsApp').factory('SituationService', function($http, $sessionSto
             result.dateDeNaissance = individu.dateDeNaissance && individu.dateDeNaissance.format('YYYY-MM-DD');
 
             if (individu.dateArriveeFoyerString) {
-                var dateArrivee = moment(individu.dateArriveeFoyerString, 'DD/MM/YYYY');
+                var dateArrivee = moment(individu.dateArriveeFoyerString, 'L');
                 if (dateArrivee.isValid()) {
                     result.dateArriveeFoyer = dateArrivee.format('YYYY-MM-DD');
                 }
             }
 
             if (individu.dateSituationFamiliale) {
-                var dateSituationFamiliale = moment(individu.dateSituationFamiliale, 'DD/MM/YYYY');
+                var dateSituationFamiliale = moment(individu.dateSituationFamiliale, 'L');
                 if (dateSituationFamiliale.isValid()) {
                     result.dateSituationFamiliale = dateSituationFamiliale.format('YYYY-MM-DD');
                 } else {

--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -156,25 +156,26 @@ angular.module('ddsApp').factory('SituationService', function($http, $sessionSto
         },
 
         createApiCompatibleIndividu: function(individu) {
-            individu = _.cloneDeep(individu);
-            individu.dateDeNaissance = moment(individu.dateDeNaissance, 'DD/MM/YYYY').format('YYYY-MM-DD');
+            var result = _.cloneDeep(individu);
+            result.dateDeNaissance = moment(individu.dateDeNaissance, 'DD/MM/YYYY').format('YYYY-MM-DD');
+
             if (individu.dateArriveeFoyerString) {
                 var dateArrivee = moment(individu.dateArriveeFoyerString, 'DD/MM/YYYY');
                 if (dateArrivee.isValid()) {
-                    individu.dateArriveeFoyer = dateArrivee.format('YYYY-MM-DD');
+                    result.dateArriveeFoyer = dateArrivee.format('YYYY-MM-DD');
                 }
             }
 
             if (individu.dateSituationFamiliale) {
                 var dateSituationFamiliale = moment(individu.dateSituationFamiliale, 'DD/MM/YYYY');
                 if (dateSituationFamiliale.isValid()) {
-                    individu.dateSituationFamiliale = dateSituationFamiliale.format('YYYY-MM-DD');
+                    result.dateSituationFamiliale = dateSituationFamiliale.format('YYYY-MM-DD');
                 } else {
-                    delete individu.dateSituationFamiliale;
+                    delete result.dateSituationFamiliale;
                 }
             }
 
-            return individu;
+            return result;
         },
 
         flattenPatrimoine: flattenPatrimoine,

--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -164,7 +164,7 @@ angular.module('ddsApp').factory('SituationService', function($http, $sessionSto
 
         createApiCompatibleIndividu: function(individu) {
             var result = _.cloneDeep(individu);
-            result.dateDeNaissance = individu.dateDeNaissance.format('YYYY-MM-DD');
+            result.dateDeNaissance = individu.dateDeNaissance && individu.dateDeNaissance.format('YYYY-MM-DD');
 
             if (individu.dateArriveeFoyerString) {
                 var dateArrivee = moment(individu.dateArriveeFoyerString, 'DD/MM/YYYY');

--- a/app/views/partials/foyer/individu-form.html
+++ b/app/views/partials/foyer/individu-form.html
@@ -9,7 +9,6 @@
         id="date-de-naissance"
         required
         ng-model="individu.dateDeNaissance"
-        ng-change="dateDeNaissanceChanged()"
         dds-date
         date-autocomplete
         date-naissance-min-age="0"

--- a/app/views/partials/foyer/individu-form.html
+++ b/app/views/partials/foyer/individu-form.html
@@ -14,7 +14,7 @@
         date-naissance-min-age="0"
         date-naissance-max-age="options.maxAge"
         auto-focus
-        placeholder="jj/mm/aaaa">
+        placeholder="JJ/MM/AAAA">
       <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.required">Ce champ est obligatoire.</p>
       <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.ddsDate">Date de naissance invalide.</p>
       <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.dateNaissanceMaxAge">

--- a/app/views/partials/foyer/individu-form.html
+++ b/app/views/partials/foyer/individu-form.html
@@ -18,10 +18,10 @@
       <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.required">Ce champ est obligatoire.</p>
       <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.ddsDate">Date de naissance invalide.</p>
       <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.dateNaissanceMaxAge">
-        Âge maximum : {{ options.maxAge }} ans.
+        Cette personne ne peut pas avoir plus de {{ options.maxAge }} ans.
       </p>
       <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.dateNaissanceMinAge">
-        Cette personne ne doit pas avoir moins de {{ options.minAge }} ans.
+        Cette personne ne peut pas avoir moins de {{ options.minAge }} ans.
       </p>
     </div>
     <div class="col-sm-4">

--- a/app/views/partials/foyer/individu-form.html
+++ b/app/views/partials/foyer/individu-form.html
@@ -16,17 +16,14 @@
         auto-focus
         placeholder="JJ/MM/AAAA">
       <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.required">Ce champ est obligatoire.</p>
-      <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.ddsDate">Date de naissance invalide.</p>
+      <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.ddsDate">
+        Veuillez utiliser le format JJ/MM/AAAA. Par exemple : 14/09/1989.
+      </p>
       <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.dateNaissanceMaxAge">
         Cette personne ne peut pas avoir plus de {{ options.maxAge }} ans.
       </p>
       <p class="help-block" ng-if="submitted && form.dateDeNaissance.$error.dateNaissanceMinAge">
         Cette personne ne peut pas avoir moins de {{ options.minAge }} ans.
-      </p>
-    </div>
-    <div class="col-sm-4">
-      <p class="help-block">
-        Format : jj/mm/aaaa, exemple : 14/09/1989
       </p>
     </div>
   </div>

--- a/app/views/partials/foyer/personnes-a-charge.html
+++ b/app/views/partials/foyer/personnes-a-charge.html
@@ -19,7 +19,7 @@
                 <i class="fa fa-child icon-lg"></i>
               </div>
               <div class="col-xs-8">
-                Né(e) le <strong>{{ enfant.dateDeNaissance.format('DD/MM/YYYY') }}</strong>
+                Né(e) le <strong>{{ enfant.dateDeNaissance.format('L') }}</strong>
                 <br>Nationalité <strong>{{ nationalite(enfant) }}</strong>
                 <br><i>{{ statutsSpecifiques(enfant) }}</i>
               </div>

--- a/app/views/partials/foyer/personnes-a-charge.html
+++ b/app/views/partials/foyer/personnes-a-charge.html
@@ -19,7 +19,7 @@
                 <i class="fa fa-child icon-lg"></i>
               </div>
               <div class="col-xs-8">
-                Né(e) le <strong>{{ enfant.dateDeNaissance }}</strong>
+                Né(e) le <strong>{{ enfant.dateDeNaissance.format('DD/MM/YYYY') }}</strong>
                 <br>Nationalité <strong>{{ nationalite(enfant) }}</strong>
                 <br><i>{{ statutsSpecifiques(enfant) }}</i>
               </div>

--- a/app/views/partials/individu-block.html
+++ b/app/views/partials/individu-block.html
@@ -4,7 +4,7 @@
     {{ individuLabel(individu) }}
   </a>
   <div>
-    Né(e) le <strong>{{ individu.dateDeNaissance.format('L') }}</strong>
+    Né(e) le <strong>{{ individu.dateDeNaissance.format('LL') }}</strong>
     <br>Nationalité <strong>{{ nationalite(individu) }}</strong>
     <br><i>{{ statutsSpecifiques(individu) }}</i>
   </div>

--- a/app/views/partials/individu-block.html
+++ b/app/views/partials/individu-block.html
@@ -4,7 +4,7 @@
     {{ individuLabel(individu) }}
   </a>
   <div>
-    Né(e) le <strong>{{ individu.dateDeNaissance }}</strong>
+    Né(e) le <strong>{{ individu.dateDeNaissance.format('DD/MM/YYYY') }}</strong>
     <br>Nationalité <strong>{{ nationalite(individu) }}</strong>
     <br><i>{{ statutsSpecifiques(individu) }}</i>
   </div>

--- a/app/views/partials/individu-block.html
+++ b/app/views/partials/individu-block.html
@@ -4,7 +4,7 @@
     {{ individuLabel(individu) }}
   </a>
   <div>
-    Né(e) le <strong>{{ individu.dateDeNaissance.format('DD/MM/YYYY') }}</strong>
+    Né(e) le <strong>{{ individu.dateDeNaissance.format('L') }}</strong>
     <br>Nationalité <strong>{{ nationalite(individu) }}</strong>
     <br><i>{{ statutsSpecifiques(individu) }}</i>
   </div>

--- a/app/views/partials/recap-situation.html
+++ b/app/views/partials/recap-situation.html
@@ -1,5 +1,5 @@
 <div class="recap-situation-test">
-  Date de valeur de la situation : {{ situation.dateDeValeur|date:'dd/MM/yyyy' }}
+  Date de valeur de la situation : {{ situation.dateDeValeur | date:'dd/MM/yyyy' }}
 
   <h4>Individus</h4>
   <div class="row">
@@ -9,7 +9,7 @@
         {{ individu.label }}
       </h5>
       <div>
-        Né(e) le {{ individu.dateDeNaissance|date:'dd/MM/yyyy' }} ({{ individu.age }} ans),
+        Né(e) le {{ individu.dateDeNaissance | date:'dd/MM/yyyy' }} ({{ individu.age }} ans),
         <br>Nationalité {{ individu.nationalite }}
         <br><i>{{ individu.statutsSpecifiques }}</i>
       </div>

--- a/test/spec/directives/date.js
+++ b/test/spec/directives/date.js
@@ -29,4 +29,10 @@ describe('directive dds-date', function() {
     $scope.$digest();
     expect(form.date.$valid).toBe(false);
   });
+
+  it('should pass with a 2-digit year', function() {
+    form.date.$setViewValue('12/08/80');
+    $scope.$digest();
+    expect(form.date.$valid).toBe(true);
+  });
 });

--- a/test/spec/services/cerfaService.js
+++ b/test/spec/services/cerfaService.js
@@ -100,9 +100,9 @@ describe('Service: cerfaService', function () {
             // given
             var service = createService();
             var situations = [
-                { individus: [{ role: 'demandeur', dateDeNaissance: '14/09/2014'}] },
-                { individus: [{ role: 'demandeur'}, { role: 'conjoint', dateDeNaissance: '14/09/2014' }] },
-                { individus: [{ role: 'demandeur', dateDeNaissance: '14/09/1989'}] }
+                { individus: [{ role: 'demandeur', dateDeNaissance: moment('14/09/2014', 'DD/MM/YYYY')}] },
+                { individus: [{ role: 'demandeur'}, { role: 'conjoint', dateDeNaissance: moment('14/09/2014', 'DD/MM/YYYY') }] },
+                { individus: [{ role: 'demandeur', dateDeNaissance: moment('14/09/1989', 'DD/MM/YYYY')}] }
             ];
 
             // when
@@ -212,12 +212,12 @@ describe('Service: cerfaService', function () {
             it('should ask piece d\'identité for french and EEE people aged >= 18', function() {
                 // given
                 var individus = [
-                    {dateDeNaissance: '14/09/1980', nationalite: 'fr'},
-                    {dateDeNaissance: '14/09/1980', nationalite: 'ue'},
+                    {dateDeNaissance: moment('14/09/1980', 'DD/MM/YYYY'), nationalite: 'fr'},
+                    {dateDeNaissance: moment('14/09/1980', 'DD/MM/YYYY'), nationalite: 'ue'},
                     // not kept because nationality not eee
-                    {dateDeNaissance: '14/09/1980', nationalite: 'autre'},
+                    {dateDeNaissance: moment('14/09/1980', 'DD/MM/YYYY'), nationalite: 'autre'},
                     // not kept because aged < 18
-                    {dateDeNaissance: '14/09/2014', nationalite: 'fr'}
+                    {dateDeNaissance: moment('14/09/2014', 'DD/MM/YYYY'), nationalite: 'fr'}
                 ];
 
                 // when
@@ -231,9 +231,9 @@ describe('Service: cerfaService', function () {
                 it('sould ask carte vitale for everybody aged >= 18', function() {
                     // given
                     var individus = [
-                        {dateDeNaissance: '14/09/1980'},
+                        {dateDeNaissance: moment('14/09/1980', 'DD/MM/YYYY')},
                         // not kept because aged < 18
-                        {dateDeNaissance: '14/09/2014'},
+                        {dateDeNaissance: moment('14/09/2014', 'DD/MM/YYYY')},
                     ];
 
                     // when
@@ -256,7 +256,7 @@ describe('Service: cerfaService', function () {
 
                 it('should ask avis d\'imposition ou non-imposition for individus aged > 16', function() {
                     // given
-                    var individus = [{dateDeNaissance: '14/08/1989'}, {dateDeNaissance: '14/09/2014'}];
+                    var individus = [{dateDeNaissance: moment('14/08/1989', 'DD/MM/YYYY')}, {dateDeNaissance: moment('14/09/2014', 'DD/MM/YYYY')}];
 
                     // when
                     var result = service.pieceJustificativeIndividus('cmu_c', 'imposition', individus);
@@ -270,11 +270,11 @@ describe('Service: cerfaService', function () {
                 it('should ask bulletins de paie for individus aged > 16 having revenus salaries', function() {
                     // given
                     var individus = [
-                        {dateDeNaissance: '14/08/1989', ressources: [{type: 'revenusSalarie'}]},
+                        {dateDeNaissance: moment('14/08/1989', 'DD/MM/YYYY'), ressources: [{type: 'revenusSalarie'}]},
                         // not kept because aged < 16
-                        {dateDeNaissance: '14/09/2014', ressources: [{type: 'revenusSalarie'}]},
+                        {dateDeNaissance: moment('14/09/2014', 'DD/MM/YYYY'), ressources: [{type: 'revenusSalarie'}]},
                         // not kept because no revenus salarie
-                        {dateDeNaissance: '14/08/1989'},
+                        {dateDeNaissance: moment('14/08/1989', 'DD/MM/YYYY')},
                     ];
 
                     // when
@@ -287,12 +287,12 @@ describe('Service: cerfaService', function () {
                 it('should ask attestations indemnités chômage for people aged > 16', function() {
                     // given
                     var individus = [
-                        {dateDeNaissance: '14/08/1989', ressources: [{type: 'allocationsChomage'}]},
-                        {dateDeNaissance: '14/08/1989', ressources: [{type: 'indChomagePartiel'}]},
+                        {dateDeNaissance: moment('14/08/1989', 'DD/MM/YYYY'), ressources: [{type: 'allocationsChomage'}]},
+                        {dateDeNaissance: moment('14/08/1989', 'DD/MM/YYYY'), ressources: [{type: 'indChomagePartiel'}]},
                         // not kept because aged > 16
-                        {dateDeNaissance: '14/08/2014', ressources: [{type: 'allocationsChomage'}]},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), ressources: [{type: 'allocationsChomage'}]},
                         // not kept because no chomage
-                        {dateDeNaissance: '14/08/2014', ressources: [{type: 'test'}]}
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), ressources: [{type: 'test'}]}
                     ];
 
                     // when
@@ -327,16 +327,16 @@ describe('Service: cerfaService', function () {
                 it('should ask acte de naissance for personnes à charge aged < 18 born in france but not french', function() {
                     // given
                     var individus = [
-                        {dateDeNaissance: '14/08/2014', nationalite: 'ue', paysNaissance: 'France', role: 'enfant'},
-                        {dateDeNaissance: '14/08/2014', nationalite: 'ue', paysNaissance: 'France', role: 'personneACharge'},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), nationalite: 'ue', paysNaissance: 'France', role: 'enfant'},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), nationalite: 'ue', paysNaissance: 'France', role: 'personneACharge'},
                         // not kept because not personne à charge
-                        {dateDeNaissance: '14/08/2014', nationalite: 'ue', paysNaissance: 'France', role: 'demandeur'},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), nationalite: 'ue', paysNaissance: 'France', role: 'demandeur'},
                         // not kept because aged > 18
-                        {dateDeNaissance: '14/08/1980', nationalite: 'ue', paysNaissance: 'France', role: 'demandeur'},
+                        {dateDeNaissance: moment('14/08/1980', 'DD/MM/YYYY'), nationalite: 'ue', paysNaissance: 'France', role: 'demandeur'},
                         // not kept because nationalite fr
-                        {dateDeNaissance: '14/08/2014', nationalite: 'fr', paysNaissance: 'France', role: 'enfant'},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), nationalite: 'fr', paysNaissance: 'France', role: 'enfant'},
                         // not kept because not born in france
-                        {dateDeNaissance: '14/08/2014', nationalite: 'ue', paysNaissance: 'Congo', role: 'personneACharge'},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), nationalite: 'ue', paysNaissance: 'Congo', role: 'personneACharge'},
                     ];
 
                     // when
@@ -349,16 +349,16 @@ describe('Service: cerfaService', function () {
                 it('should ask certificat OFII if aged < 18 and foreigner', function() {
                     // given
                     var individus = [
-                        {dateDeNaissance: '14/08/2014', nationalite: 'ue', paysNaissance: 'Malaisie', role: 'enfant'},
-                        {dateDeNaissance: '14/08/2014', nationalite: 'ue', paysNaissance: 'Congo', role: 'personneACharge'},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), nationalite: 'ue', paysNaissance: 'Malaisie', role: 'enfant'},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), nationalite: 'ue', paysNaissance: 'Congo', role: 'personneACharge'},
                         // not kept because not personne à charge
-                        {dateDeNaissance: '14/08/2014', nationalite: 'ue', paysNaissance: 'France', role: 'demandeur'},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), nationalite: 'ue', paysNaissance: 'France', role: 'demandeur'},
                         // not kept because aged > 18
-                        {dateDeNaissance: '14/08/1980', nationalite: 'ue', paysNaissance: 'France', role: 'demandeur'},
+                        {dateDeNaissance: moment('14/08/1980', 'DD/MM/YYYY'), nationalite: 'ue', paysNaissance: 'France', role: 'demandeur'},
                         // not kept because nationalite fr
-                        {dateDeNaissance: '14/08/2014', nationalite: 'fr', paysNaissance: 'France', role: 'enfant'},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), nationalite: 'fr', paysNaissance: 'France', role: 'enfant'},
                         // not kept because born in france
-                        {dateDeNaissance: '14/08/2014', nationalite: 'ue', paysNaissance: 'France', role: 'personneACharge'},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), nationalite: 'ue', paysNaissance: 'France', role: 'personneACharge'},
                     ];
 
                     // when
@@ -373,9 +373,9 @@ describe('Service: cerfaService', function () {
                     var individus = [
                         {nationalite: 'autre', paysNaissance: 'Malaisie', role: 'demandeur'},
                         {nationalite: 'autre', paysNaissance: 'Congo', role: 'conjoint'},
-                        {dateDeNaissance: '14/08/1980', nationalite: 'autre', paysNaissance: 'Congo', role: 'enfant'},
+                        {dateDeNaissance: moment('14/08/1980', 'DD/MM/YYYY'), nationalite: 'autre', paysNaissance: 'Congo', role: 'enfant'},
                         // not kept because child < 18
-                        {dateDeNaissance: '14/08/2014', nationalite: 'autre', paysNaissance: 'Congo', role: 'enfant'},
+                        {dateDeNaissance: moment('14/08/2014', 'DD/MM/YYYY'), nationalite: 'autre', paysNaissance: 'Congo', role: 'enfant'},
                         // not kept because nationalite eee
                         {nationalite: 'ue', role: 'demandeur'},
                     ];

--- a/test/spec/services/situationService.js
+++ b/test/spec/services/situationService.js
@@ -16,7 +16,7 @@ describe('Service: situationService', function () {
     describe('function createApiCompatibleIndividu()', function() {
         it('Should return a cloned version of the individu', function() {
             // given
-            var individu = { dateDeNaissance: '14/09/1989' };
+            var individu = { dateDeNaissance: moment('14/09/1989', 'DD/MM/YYYY') };
 
             // when
             var result = service.createApiCompatibleIndividu(individu);
@@ -27,7 +27,7 @@ describe('Service: situationService', function () {
 
         it('Should format birth date as expected by the api', function() {
             // given
-            var individu = { dateDeNaissance: '14/09/1989' };
+            var individu = { dateDeNaissance: moment('14/09/1989', 'DD/MM/YYYY') };
 
             // when
             var result = service.createApiCompatibleIndividu(individu);


### PR DESCRIPTION
- Les dates peuvent être saisies sur deux chiffres (fixes #24).
- La date de naissance est présentée dans le récapitulatif situation avec un nom de mois entier.
![Saisie d'année sur deux chiffre](https://cloud.githubusercontent.com/assets/222463/7303225/45350926-e9ef-11e4-8b55-86c6deea54f9.png)
- Les instances d'individus dans une situation représentent toujours leurs `dateDeNaissance` comme une instance de `moment` et non comme un `String` systématiquement parsé et formaté.
- Le formatage attendu n'est précisé qu'en cas d'erreur de saisie.
![Message d'erreur formatage](https://cloud.githubusercontent.com/assets/222463/7303233/599d5a58-e9ef-11e4-9434-ba4028c657af.png)