### PR TITLE
Modifs mineures pour les directives ddsDate / dateAutocomplete

### DIFF
--- a/app/js/directives/date.js
+++ b/app/js/directives/date.js
@@ -5,7 +5,7 @@ angular.module('ddsApp').directive('ddsDate', function() {
         require: 'ngModel',
         link: function(scope, elm, attrs, ctrl) {
             ctrl.$parsers.push(function(viewValue) {
-                var result = moment(viewValue, ['DD/MM/YY', 'L', 'LL']);
+                var result = moment(viewValue, ['DD/MM/YY', 'L', 'LL'], true);
 
                 ctrl.$setValidity('ddsDate', result.isValid());
 

--- a/app/js/directives/dateAutocomplete.js
+++ b/app/js/directives/dateAutocomplete.js
@@ -7,6 +7,14 @@ angular.module('ddsApp').directive('dateAutocomplete', function() {
         link: function(scope, element, attrs, ngModel) {
             var lastViewValue = '';
             ngModel.$parsers.unshift(function(viewValue) {
+                if (viewValue.length > 10) {
+                    var maxLengthValue = viewValue.substring(0, 10);
+                    ngModel.$setViewValue(maxLengthValue);
+                    ngModel.$render();
+
+                    return maxLengthValue;
+                }
+
                 var previousValue = lastViewValue;
                 lastViewValue = viewValue;
 


### PR DESCRIPTION
J'ai utilisé la même directive sur impact et fait deux modifications que trouve utiles.
La première rend la validation de moment.js plus stricte, cela permet de ne pas accepter les dates 01/01/1999f
La deuxième empêche le champs date de faire plus de 10 caractères.