### PR TITLE
Intégration des retours de la campagne  de tests 

### DIFF
--- a/app/js/controllers/foyer/logement.js
+++ b/app/js/controllers/foyer/logement.js
@@ -12,9 +12,9 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
     $scope.logementTypes = logementTypes;
     $scope.locationTypes = locationTypes;
 
-    $scope.cityStartsWith = function cityStartsWith(prefix) {
+    function cityStartsWith(prefix) {
         return logement.adresse.nomCommune && logement.adresse.nomCommune.indexOf(prefix.toUpperCase()) === 0;
-    };
+    }
 
     $scope.yearsAgo = function yearsAgo(amount) {
         return moment().subtract(amount, 'years').format('MMMM YYYY');
@@ -70,6 +70,10 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
         ]);
     };
 
+    $scope.captureResidentParis = function() {
+        return $scope.captureCodePostal() && logement.type != 'sansDomicile' && cityStartsWith('Paris');
+    };
+
     $scope.changeLogementType = function() {
         ['colocation', 'locationType', 'membreFamilleProprietaire', 'primoAccedant', 'loyer', 'charges', 'isChambre'].forEach(function(field) {
             delete logement[field];
@@ -93,7 +97,7 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
     $scope.submit = function(form) {
         $scope.submitted = true;
         if (form.$valid && logement.adresse) {
-            logement.inhabitantForThreeYearsOutOfLastFive = logement.inhabitantForThreeYearsOutOfLastFive && $scope.cityStartsWith('Paris');
+            logement.inhabitantForThreeYearsOutOfLastFive = logement.inhabitantForThreeYearsOutOfLastFive && cityStartsWith('Paris');
             $scope.$emit('logement', logement);
         }
     };

--- a/app/styles/front.scss
+++ b/app/styles/front.scss
@@ -294,6 +294,10 @@ $autre-lighter: #cce4e7;
   &.active {
     background-color: $btn-success-bg;
     color: white;
+    &:focus, &:hover {
+      background-color: $btn-success-bg;
+      color: white;
+    }
   }
 }
 

--- a/app/views/partials/foyer/logement.html
+++ b/app/views/partials/foyer/logement.html
@@ -158,7 +158,7 @@
       </div>
     </div>
 
-    <div class="form-group" ng-if="captureCodePostal() && cityStartsWith('Paris')">
+    <div class="form-group" ng-if="captureResidentParis()">
       <label class="col-sm-3 control-label">Avez-vous habité Paris au moins 3 ans depuis {{ yearsAgo(5) }}&nbsp;?</label>
       <div class="col-sm-3">
         <button type="button" class="btn btn-sm btn-default" ng-model="logement.inhabitantForThreeYearsOutOfLastFive" btn-radio="true">Oui</button>

--- a/app/views/partials/simulation.html
+++ b/app/views/partials/simulation.html
@@ -9,9 +9,9 @@
   <p>Une erreur est survenue dans la simulation.</p>
 </div>
 
-<p ng-if="!error && !awaitingResults">D'après la situation que vous avez décrite, vous êtes a priori éligible aux aides suivantes : </p>
+<p ng-if="!error && !awaitingResults && !noDroits">D'après la situation que vous avez décrite, vous êtes a priori éligible aux aides suivantes : </p>
 <div class="frame-resultats" ng-if="!error && !awaitingResults">
-  <accordion close-others="true">
+  <accordion close-others="true" ng-if="!noDroits">
     <accordion-group is-open="droit.open"
                      class="resultats-accordion"
                      ng-repeat="(droitId, droit) in droits"

--- a/app/views/partials/simulation.html
+++ b/app/views/partials/simulation.html
@@ -137,11 +137,6 @@
   <h4 ng-show="! (droitsInjectes | isEmpty)">Aides que vous percevez déjà aujourd'hui, et dont nous n'avons pas recalculé le montant</h4>
   <droits-list droits="droitsInjectes"></droits-list>
 
-  <h4>Aides étudiées pour lesquelles vous n'êtes <span ng-if="! situation.ressourcesYearMoins2Captured && ! error">a priori</span> pas éligible</h4>
-  <droits-list droits="droitsNonEligibles"></droits-list>
-
-<hr>
-
 <p class="text-right">
   <em>
     Vous pensez que le droit applicable à votre situation n'est pas correctement estimé par ce simulateur ?

--- a/app/views/partials/simulation.html
+++ b/app/views/partials/simulation.html
@@ -1,6 +1,8 @@
-<h1><i class="fa fa-gears"></i> Résultats de votre simulation</h1>
+<h1> Résultats de votre simulation</h1>
+
 
 <p ng-if="awaitingResults"><i class="fa fa-spinner fa-spin"></i> Calcul en cours de vos droits…</p>
+
 
 <div class="alert alert-danger" ng-if="error">
   <h2>Désolé, nous n'arrivons pas à calculer vos droits pour le moment.</h2>

--- a/app/views/partials/simulation.html
+++ b/app/views/partials/simulation.html
@@ -1,4 +1,4 @@
-<h1> Résultats de votre simulation</h1>
+<h1>Résultats de votre simulation</h1>
 
 
 <p ng-if="awaitingResults"><i class="fa fa-spinner fa-spin"></i> Calcul en cours de vos droits…</p>

--- a/app/views/partials/simulation.html
+++ b/app/views/partials/simulation.html
@@ -9,6 +9,7 @@
   <p>Une erreur est survenue dans la simulation.</p>
 </div>
 
+<p ng-if="!error && !awaitingResults">D'après la situation que vous avez décrite, vous êtes a priori éligible aux aides suivantes : </p>
 <div class="frame-resultats" ng-if="!error && !awaitingResults">
   <accordion close-others="true">
     <accordion-group is-open="droit.open"


### PR DESCRIPTION
Fixes #139 

- [x] Ne pas demander au SDS à Paris depuis combien de temps ils y habitent
- [x] Ne pas afficher la liste des prestations auxquels le demandeur n'est pas éligible
- [x] Pas de symbole d'engrenage dans la page résultat
- [x] Phrase d'introduction au résultat pour indiquer que c'est fini
- [x] Résolution du problème lié au focus identifié sur la page des pensions alimentaires versées (case grisée)

Les retours sur les ressources (écran principal + N-2) seront traités dans des PR séparées. 

@MattiSG , anything else ?
