### PR TITLE
[Quick fix] Make it more clear we need the user to declare disabled adults too

### DIFF
--- a/app/views/partials/foyer/personnes-a-charge.html
+++ b/app/views/partials/foyer/personnes-a-charge.html
@@ -2,7 +2,7 @@
   <h1>Les enfants de votre foyer</h1>
 
   <div class="help-block">
-    <p>Les personnes de <span data-tooltip="Les personnes à votre charge de plus de 25 ans non handicapées ne changent pas votre éligibilité aux aides calculées par ce simulateur.">moins de 25 ans</span> ou handicapées dont vous assumez la responsabilité, même sans lien de parenté.</p>
+    <p>Les personnes de <span data-tooltip="Les personnes à votre charge de plus de 25 ans non handicapées ne changent pas votre éligibilité aux aides calculées par ce simulateur.">moins de 25 ans ou handicapées</span> dont vous assumez la responsabilité, même sans lien de parenté.</p>
   </div>
 
   <div class="row">


### PR DESCRIPTION
Aujourd'hui, le simulateur est trompeur et n'incite pas le ben pot a déclarer ses personnes à charges handicapées. 