### PR TITLE
Disable pensions alimentaires browser validation

### DIFF
--- a/app/views/partials/foyer/pensions-alimentaires.html
+++ b/app/views/partials/foyer/pensions-alimentaires.html
@@ -1,5 +1,5 @@
 <div class="frame-foyer">
-  <form class="form-horizontal" ng-submit="submit()">
+  <form class="form-horizontal" novalidate ng-submit="submit()">
     <h1>Pensions alimentaires versées</h1>
 
     <div class="form-group">


### PR DESCRIPTION
Allow setting any value while keeping `step` amounts for arrows usage in input fields.
Connected to #179. Could supersede #190.