### PR TITLE
Changer les adresses mails et faciliter le feedback

### DIFF
--- a/app/views/front.html
+++ b/app/views/front.html
@@ -89,7 +89,7 @@
             <li><a ui-sref="cgu">Mentions légales</a></li>
             <li><a ui-sref="contribuez">Contribuez !</a></li>
             <li><a ui-sref="faq">FAQ</a></li>
-            <li><a href="mailto:mes-aides@sgmap.fr">Contact</a></li>
+            <li><a href="mailto:contact@mes-aides.gouv.fr ">Contact</a></li>
           </ul>
         </div>
         <div class="col-md-2 hidden-sm hidden-xs">

--- a/app/views/partials/error-modal.html
+++ b/app/views/partials/error-modal.html
@@ -3,7 +3,7 @@
 </div>
 <div class="modal-body">
   <p>
-    Merci de prévenir l'équipe mes-aides en <a href="mailto:mes-aides@sgmap.fr?subject=Erreur">envoyant un email</a> à mes-aides@sgmap.fr en décrivant ce que vous faisiez avant que cette erreur n'apparaisse, et en joignant si possible une capture d'écran.
+    Merci de prévenir l'équipe mes-aides en <a href="mailto:bug@mes-aides.gouv.fr">envoyant un email</a> à bug@mes-aides.gouv.fr en décrivant ce que vous faisiez avant que cette erreur n'apparaisse, et en joignant si possible une capture d'écran.
   </p>
   <p>
     Nous vous répondrons au plus vite et corrigerons le problème dès que possible.

--- a/app/views/partials/faq.html
+++ b/app/views/partials/faq.html
@@ -18,7 +18,7 @@
   <p>Toute simulation est anonyme. Mes Aides ne stocke aucune information personnelle.</p>
 
   <h3>Comment contribuer à l’amélioration du simulateur ?</h3>
-  <p>L’équipe Mes Aides est à l’écoute de tous vos retours. Vous pouvez nous écrire à l’adresse contribuer-mes-aides@sgmap.fr. Si vous obtenez un résultat inattendu de la part du simulateur, vous pouvez nous en faire part en enregistrant le cas en fin de simulation. Nous vous créerons un compte pour que vous puissiez contribuer sur notre plateforme de tests.</p>
+  <p>L’équipe Mes Aides est à l’écoute de tous vos retours. Vous pouvez nous écrire à l’adresse contribuer@mes-aides.gouv.fr. Si vous obtenez un résultat inattendu de la part du simulateur, vous pouvez nous en faire part en enregistrant le cas en fin de simulation. Nous vous créerons un compte pour que vous puissiez contribuer sur notre plateforme de tests.</p>
 
   <h3 id="recours">J'ai un problème avec les services de l'État, puis-je vous envoyer ma situation personnelle pour que vous m'aidiez ?</h3>
   <p>Mes-aides n'est qu'un site Internet qui vous aide à mieux comprendre vos droits et simplifier vos démarches. En cas de problème, nous vous recommandons de contacter directement les services concernés, les liens suivants vous permettront de les retrouver&nbsp;:

--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -171,9 +171,15 @@
   <droits-list droits="droitsInjectes"></droits-list>
 
 <p class="text-right">
+  <em><b>
+    Nous construisons ce simulateur en amélioration continue. Vous souhaitez nous transmettre vos retours et suggestions ?
+    <br><a href="mailto:feedback@mes-aides.gouv.fr">Cliquez ici</a>
+  </b></em>
+</p>
+
+<p class="text-right">
   <em>
-    Vous pensez que le droit applicable à votre situation n'est pas correctement estimé par ce simulateur ?
-    <br>Vous êtes en mesure de nous fournir une information précise sur vos droits ?
-    <br><a href="" ng-click="createTest()">Cliquez ici</a>.
+    <br>Partenaires, contribuez à la fiabilité du simulateur:
+    <br><a href="" ng-click="createTest()">Créez un test</a>
   </em>
 </p>

--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -173,5 +173,5 @@
 <p class="text-right">
   <strong>Nous améliorons ce simulateur en continu. N'hésitez pas à <a href="mailto:feedback@mes-aides.gouv.fr">nous transmettre vos retours et suggestions</a>&nbsp;!</strong>
   <br/>
-  <small>Partenaires: <a href="" ng-click="createTest()">créez un test</a>.</small>
+  <small>Partenaires&nbsp;: <a href="" ng-click="createTest()">créez un test</a>.</small>
 </p>

--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -171,15 +171,7 @@
   <droits-list droits="droitsInjectes"></droits-list>
 
 <p class="text-right">
-  <em><b>
-    Nous construisons ce simulateur en amélioration continue. Vous souhaitez nous transmettre vos retours et suggestions ?
-    <br><a href="mailto:feedback@mes-aides.gouv.fr">Cliquez ici</a>
-  </b></em>
-</p>
-
-<p class="text-right">
-  <em>
-    <br>Partenaires, contribuez à la fiabilité du simulateur:
-    <br><a href="" ng-click="createTest()">Créez un test</a>
-  </em>
+  <strong>Nous améliorons ce simulateur en continu. N'hésitez pas à <a href="mailto:feedback@mes-aides.gouv.fr">nous transmettre vos retours et suggestions</a>&nbsp;!</strong>
+  <br/>
+  <small><a href="" ng-click="createTest()">Signaler une erreur de calcul</a></small>
 </p>

--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -173,5 +173,5 @@
 <p class="text-right">
   <strong>Nous améliorons ce simulateur en continu. N'hésitez pas à <a href="mailto:feedback@mes-aides.gouv.fr">nous transmettre vos retours et suggestions</a>&nbsp;!</strong>
   <br/>
-  <small><a href="" ng-click="createTest()">Signaler une erreur de calcul</a></small>
+  <small>Partenaires: <a href="" ng-click="createTest()">créez un test</a>.</small>
 </p>


### PR DESCRIPTION
En tant que bénéficiaire potentiel qui vient de voir ses résulats,
Je vois directement le lien me permettant de contacter l'équipe.
Je ne suis pas attiré par un "Cliquez ici" qui me demande des identifiants.

En tant que partenaire souhaitant créez un test,
Je vois directement un lien explicite me permettant de le faire.

En tant que membre de l'équipe,
Je reçois des mails entrants identifiées comme feedback à une adresse distincte de la mailing list habituelle.
Je n'ai plus à expliquer aux bénéficiaires potentiels qu'ils n'ont pas besoin d'identifiants.

Proposition de rédaction : 
![image](https://cloud.githubusercontent.com/assets/11834997/13150448/200f4350-d666-11e5-8bc9-2a3f3ecafccc.png)
