### PR TITLE
Switch interrupted resources wording back to positive and handle specific cases

### DIFF
--- a/app/js/constants/ressources.js
+++ b/app/js/constants/ressources.js
@@ -32,7 +32,8 @@ angular.module('ddsCommon').constant('ressourceTypes', [
         id: 'revenusSalarie',
         label: 'Salaire, primes',
         category: 'revenusActivite',
-        prefix: 'un'
+        prefix: 'un',
+        positionInList: '1'
     },
     {
         id: 'stage',

--- a/app/js/constants/ressources.js
+++ b/app/js/constants/ressources.js
@@ -30,138 +30,166 @@ angular.module('ddsCommon').constant('ressourceCategories', [
 angular.module('ddsCommon').constant('ressourceTypes', [
     {
         id: 'revenusSalarie',
-        label: 'Salaires, primes',
-        category: 'revenusActivite'
+        label: 'Salaire, primes',
+        category: 'revenusActivite',
+        prefix: 'un'
     },
     {
         id: 'stage',
         label: 'Rémunération de stage',
-        category: 'revenusActivite'
+        category: 'revenusActivite',
+        prefix: 'une'
     },
     {
         id: 'revenusStageFormationPro',
         label: 'Revenus de stage de formation professionnelle',
-        category: 'revenusActivite'
+        category: 'revenusActivite',
+        prefix: 'des'
     },
     {
         id: 'allocationsChomage',
-        label: 'Allocation chômage (ARE)',
-        category: 'allocations'
+        label: 'Allocations chômage (ARE)',
+        category: 'allocations',
+        prefix: 'des'
     },
     {
         id: 'allocationSecurisationPro',
         label: 'Allocation de sécurisation professionnelle',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'une'
     },
     {
         id: 'primeRepriseActivite',
         label: 'Prime forfaitaire mensuelle pour la reprise d’activité',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'une'
     },
     {
         id: 'aide_logement',
         label: 'Aides au logement (APL, ALS, ALF)',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'des'
     },
     {
         id: 'af',
         label: 'Allocations familiales',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'des'
     },
     {
         id: 'cf',
         label: 'Complément familial (CF)',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'le'
     },
     {
         id: 'asf',
         label: 'Allocation de soutien familial (ASF)',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'l’'
     },
     {
         id: 'rsa',
         label: 'Revenu de solidarité active (RSA)',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'le'
     },
     {
         id: 'aspa',
         label: 'Allocation de solidarité aux personnes âgées (ASPA)',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'l’'
     },
     {
         id: 'asi',
         label: 'Allocation supplémentaire d’invalidité (ASI)',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'l’'
     },
     {
         id: 'ass',
         label: 'Allocation de solidarité spécifique (ASS)',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'l’'
+
     },
     {
         id: 'aah',
         label: 'Allocation adulte handicapé (AAH)',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'l’'
     },
     {
         id: 'aeeh',
         label: 'Allocation d’éducation de l’enfant handicapé (AEEH)',
-        category: 'allocations'  // We don't actually need to capture the amount, but users want to declare it, and presence can improve some Paris aides. See https://github.com/sgmap/mes-aides-ui/issues/191
+        category: 'allocations',
+        prefix: 'l’'  // We don't actually need to capture the amount, but users want to declare it, and presence can improve some Paris aides. See https://github.com/sgmap/mes-aides-ui/issues/191
     },
     {
         id: 'paje_base',
         label: 'Prestation d’accueil du jeune enfant (PAJE) - Allocation de base',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'la'
     },
     {
         id: 'clca',
         label: 'Complément de libre choix d’activité (CLCA)',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'le'
     },
     {
         id: 'prepare',
         label: 'Prestation partagée d’éducation de l’enfant (PreParE)',
-        category: 'allocations'
+        category: 'allocations',
+        prefix: 'la'
     },
     {
         id: 'indJourMaternite',
         label: 'Indemnités de maternité, paternité, adoption',
-        category: 'indemnites'
+        category: 'indemnites',
+        prefix: 'des'
     },
     {
         id: 'indJourMaladie',
         label: 'Indemnités maladie',
-        category: 'indemnites'
+        category: 'indemnites',
+        prefix: 'des'
     },
     {
         id: 'indJourMaladieProf',
         label: 'Indemnités maladie professionnelle',
-        category: 'indemnites'
+        category: 'indemnites',
+        prefix: 'des'
     },
     {
         id: 'indJourAccidentDuTravail',
         label: 'Indemnités d’accident du travail',
-        category: 'indemnites'
+        category: 'indemnites',
+        prefix: 'des'
     },
     {
         id: 'indChomagePartiel',
         label: 'Indemnités d’activité partielle',
-        category: 'indemnites'
+        category: 'indemnites',
+        prefix: 'des'
     },
     {
         id: 'indVolontariat',
         label: 'Indemnités de volontariat',
-        category: 'indemnites'
+        category: 'indemnites',
+        prefix: 'des'
     },
     {
         id: 'dedommagementAmiante',
         label: 'Dédommagement aux victimes de l’amiante',
-        category: 'indemnites'
+        category: 'indemnites',
+        prefix: 'un'
     },
     {
         id: 'pensionsAlimentaires',
-        label: 'Pensions alimentaires',
-        category: 'pensions'
+        label: 'Pension alimentaire',
+        category: 'pensions',
+        prefix: 'une'
     },
     {
         id: 'pensionsAlimentairesVersees',
@@ -171,37 +199,44 @@ angular.module('ddsCommon').constant('ressourceTypes', [
     {
         id: 'prestationCompensatoire',
         label: 'Prestation compensatoire (suite à séparation)',
-        category: 'pensions'
+        category: 'pensions',
+        prefix: 'une'
     },
     {
         id: 'pensionsRetraitesRentes',
-        label: 'Retraite (y compris reversion), rentes',
-        category: 'pensions'
+        label: 'Retraite (y compris reversion), rente',
+        category: 'pensions',
+        prefix: 'une'
     },
     {
         id: 'retraiteCombattant',
         label: 'Retraite du combattant',
-        category: 'pensions'
+        category: 'pensions',
+        prefix: 'une'
     },
     {
         id: 'pensionsInvalidite',
-        label: 'Pensions d’invalidité',
-        category: 'pensions'
+        label: 'Pension d’invalidité',
+        category: 'pensions',
+        prefix: 'une'
     },
     {
         id: 'bourseEnseignementSup',
-        label: 'Bourses de l’enseignement supérieur',
-        category: 'autre'
+        label: 'Bourse de l’enseignement supérieur',
+        category: 'autre',
+        prefix: 'une'
     },
     {
         id: 'bourseRecherche',
         label: 'Bourse de recherche',
-        category: 'autre'
+        category: 'autre',
+        prefix: 'une'
     },
     {
         id: 'gainsExceptionnels',
         label: 'Gains exceptionnels (dons, gains aux jeux, héritage)',
-        category: 'autre'
+        category: 'autre',
+        prefix: 'des'
     },
     {
         id: 'caMicroEntreprise',

--- a/app/js/constants/ressources.js
+++ b/app/js/constants/ressources.js
@@ -27,12 +27,14 @@ angular.module('ddsCommon').constant('ressourceCategories', [
     }
 ]);
 
+var ijssInteruptionQuestionLabel = 'des indemnités de la sécurité sociale, un salaire ou des allocations chômage';
+
 angular.module('ddsCommon').constant('ressourceTypes', [
     {
         id: 'revenusSalarie',
         label: 'Salaire, primes',
         category: 'revenusActivite',
-        prefix: 'un',
+        interuptionQuestionLabel: 'un salaire, des allocations chômage, ou des indemnités de la sécurité sociale',
         positionInList: '1'
     },
     {
@@ -51,7 +53,7 @@ angular.module('ddsCommon').constant('ressourceTypes', [
         id: 'allocationsChomage',
         label: 'Allocations chômage (ARE)',
         category: 'allocations',
-        prefix: 'des'
+        interuptionQuestionLabel: 'des allocations chômage, un salaire ou des indemnités de la sécurité sociale'
     },
     {
         id: 'allocationSecurisationPro',
@@ -148,25 +150,25 @@ angular.module('ddsCommon').constant('ressourceTypes', [
         id: 'indJourMaternite',
         label: 'Indemnités de maternité, paternité, adoption',
         category: 'indemnites',
-        prefix: 'des'
+        interuptionQuestionLabel: ijssInteruptionQuestionLabel
     },
     {
         id: 'indJourMaladie',
         label: 'Indemnités maladie',
         category: 'indemnites',
-        prefix: 'des'
+        interuptionQuestionLabel: ijssInteruptionQuestionLabel
     },
     {
         id: 'indJourMaladieProf',
         label: 'Indemnités maladie professionnelle',
         category: 'indemnites',
-        prefix: 'des'
+        interuptionQuestionLabel: ijssInteruptionQuestionLabel
     },
     {
         id: 'indJourAccidentDuTravail',
         label: 'Indemnités d’accident du travail',
         category: 'indemnites',
-        prefix: 'des'
+        interuptionQuestionLabel: ijssInteruptionQuestionLabel
     },
     {
         id: 'indChomagePartiel',

--- a/app/js/constants/ressources.js
+++ b/app/js/constants/ressources.js
@@ -196,8 +196,9 @@ angular.module('ddsCommon').constant('ressourceTypes', [
     },
     {
         id: 'pensionsAlimentairesVersees',
-        label: 'Pensions alimentaires versées',
-        category: 'pensions'
+        label: 'Pension alimentaire versée',
+        category: 'pensions',
+        interuptionQuestionLabel: 'une pension alimentaire',
     },
     {
         id: 'prestationCompensatoire',

--- a/app/js/controllers/foyer/pensionsAlimentaires.js
+++ b/app/js/controllers/foyer/pensionsAlimentaires.js
@@ -37,7 +37,7 @@ angular.module('ddsApp').controller('FoyerPensionsAlimentairesCtrl', function($s
                 type: $scope.pensionsVersees,
                 montantsMensuels: initMontantsMensuels(individu, 'pensionsAlimentairesVersees'),
                 montantAnnuel: initMontantAnnuel(individu, 'pensionsAlimentairesVersees'),
-                interrupted: false
+                onGoing: true
             }
         };
 

--- a/app/js/controllers/foyer/ressources/ressources.js
+++ b/app/js/controllers/foyer/ressources/ressources.js
@@ -9,7 +9,7 @@ angular.module('ddsApp').controller('FoyerRessourcesCtrl', function($scope, $sta
 
     $scope.autoEntrepreneurOnGoingQuestion = function(individu, currentMonth) {
         var prefix = {
-            'demandeur': 'J’aurai',
+            'demandeur': 'Vous aurez',
             'conjoint': 'Votre conjoint aura',
             'enfant': individu.firstName + ' aura'
         }[individu.role];

--- a/app/js/controllers/foyer/ressources/ressources.js
+++ b/app/js/controllers/foyer/ressources/ressources.js
@@ -8,7 +8,7 @@ angular.module('ddsApp').controller('FoyerRessourcesCtrl', function($scope, $sta
     $scope.currentMonth = moment($scope.situation.dateDeValeur).format('MMMM YYYY');
 
     // Pour les Auto-entrepreneurs
-    $scope.interruptedLabel = 'J’aurai un chiffre d’affaires non nul en ' + $scope.currentMonth;
+    $scope.onGoingLabel = 'J’aurai un chiffre d’affaires non nul en ' + $scope.currentMonth;
 
     $scope.ressourceTypes = _.indexBy(ressourceTypes, 'id');
 
@@ -60,7 +60,7 @@ angular.module('ddsApp').controller('FoyerRessourcesCtrl', function($scope, $sta
                 type: ressourceType,
                 montantsMensuels: montantsMensuels,
                 montantAnnuel: montantAnnuel,
-                interrupted: false
+                onGoing: true
             };
 
             // For autres revenus TNS, we also need to find the CA
@@ -75,7 +75,7 @@ angular.module('ddsApp').controller('FoyerRessourcesCtrl', function($scope, $sta
             }
 
             if (_.contains(individu.interruptedRessources, type)) {
-                ressource.interrupted = true;
+                ressource.onGoing = false;
             }
             result.push(ressource);
         });

--- a/app/js/controllers/foyer/ressources/ressources.js
+++ b/app/js/controllers/foyer/ressources/ressources.js
@@ -7,8 +7,14 @@ angular.module('ddsApp').controller('FoyerRessourcesCtrl', function($scope, $sta
     $scope.yearMoinsUn = moment($scope.situation.dateDeValeur).subtract('years', 1).format('YYYY');
     $scope.currentMonth = moment($scope.situation.dateDeValeur).format('MMMM YYYY');
 
-    // Pour les Auto-entrepreneurs
-    $scope.onGoingLabel = 'J’aurai un chiffre d’affaires non nul en ' + $scope.currentMonth;
+    $scope.autoEntrepreneurOnGoingQuestion = function(individu, currentMonth) {
+        var prefix = {
+            'demandeur': 'J’aurai',
+            'conjoint': 'Votre conjoint aura',
+            'enfant': individu.firstName + ' aura'
+        }[individu.role];
+        return prefix + ' un chiffre d’affaires non nul en ' + currentMonth + '.';
+    };
 
     $scope.ressourceTypes = _.indexBy(ressourceTypes, 'id');
 

--- a/app/js/controllers/foyer/ressources/types.js
+++ b/app/js/controllers/foyer/ressources/types.js
@@ -23,7 +23,7 @@ angular.module('ddsApp').controller('FoyerRessourceTypesCtrl', function($scope, 
         montantAnnuel: 0,
         caAnnuel: 0,
         montantsMensuels: [0, 0, 0],
-        interrupted: false,
+        onGoing: true,
     };
 
     $scope.pageTitle = pageTitle();

--- a/app/js/directives/captureMontantRessource.js
+++ b/app/js/directives/captureMontantRessource.js
@@ -1,8 +1,17 @@
 'use strict';
 
 angular.module('ddsApp').directive('montantRessource', function(SituationService) {
-    function getFormattedLabel (ressource) {
-        return ressource.interuptionQuestionLabel || ressource.prefix + ' ' + ressource.label.slice(0,1).toLowerCase() + ressource.label.slice(1);
+    function getOnGoingQuestion (individu, ressource, currentMonth) {
+        var subject = {
+            'demandeur': 'Je',
+            'conjoint': 'Votre conjoint',
+            'enfant': individu.firstName
+        }[individu.role],
+            verbPrefix = ressource.id == 'pensionsAlimentairesVersees' ? 'verser' : 'percevr',
+            verbSufix = individu.role == 'demandeur' ? 'ai' : 'a',
+            ressourceLabel = ressource.interuptionQuestionLabel || ressource.prefix + ' ' + ressource.label.slice(0,1).toLowerCase() + ressource.label.slice(1);
+
+        return [subject, verbPrefix + verbSufix, ressourceLabel, 'en', currentMonth].join(' ') + '.';
     }
 
     return {
@@ -11,11 +20,10 @@ angular.module('ddsApp').directive('montantRessource', function(SituationService
         replace: true,
         templateUrl: 'partials/foyer/capture-montant-ressource.html',
         scope: {
-            shortLabel: '=',
+            individuVM: '=',
             ressourceType: '=',
             dateDeValeur: '=',
             index: '=',
-            onGoingLabel: '=?',
             form: '=',
         },
         link: function(scope, element, attrs, ngModel) {
@@ -24,10 +32,7 @@ angular.module('ddsApp').directive('montantRessource', function(SituationService
             scope.months = SituationService.getMonths(scope.dateDeValeur);
             scope.currentMonth = moment(scope.dateDeValeur).format('MMMM YYYY');
             scope.isNumber = angular.isNumber;
-
-            if (! scope.onGoingLabel) {
-                scope.onGoingLabel = 'Je percevrai ' + getFormattedLabel(scope.ressourceType) + ' en ' + scope.currentMonth + '.';
-            }
+            scope.onGoingLabel = getOnGoingQuestion(scope.individuVM.individu, scope.ressourceType, scope.currentMonth);
 
             function checkSumConsistency() {
                 scope.monthsSum = scope.ressource.montantsMensuels.reduce(function(sum, current) {

--- a/app/js/directives/captureMontantRessource.js
+++ b/app/js/directives/captureMontantRessource.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('ddsApp').directive('montantRessource', function(SituationService) {
-    function getFormattedLabel (ressourceLabel) {
-        return (/^[aàeéèêëiîïoöôuüy]/i.test(ressourceLabel) ? 'd’' : 'de ') + ressourceLabel.slice(0,1).toLowerCase() + ressourceLabel.slice(1);
+    function getFormattedLabel (ressource) {
+        return ressource.prefix + ' ' + ressource.label.slice(0,1).toLowerCase() + ressource.label.slice(1);
     }
 
     return {
@@ -26,7 +26,7 @@ angular.module('ddsApp').directive('montantRessource', function(SituationService
             scope.isNumber = angular.isNumber;
 
             if (! scope.onGoingLabel) {
-                scope.onGoingLabel = 'Je continuerai à percevoir cette ressource en ' + scope.currentMonth;
+                scope.onGoingLabel = 'Je percevrai ' + getFormattedLabel(scope.ressourceType) + ' en ' + scope.currentMonth + '.';
             }
 
             function checkSumConsistency() {

--- a/app/js/directives/captureMontantRessource.js
+++ b/app/js/directives/captureMontantRessource.js
@@ -15,7 +15,7 @@ angular.module('ddsApp').directive('montantRessource', function(SituationService
             ressourceType: '=',
             dateDeValeur: '=',
             index: '=',
-            interruptedLabel: '=?',
+            onGoingLabel: '=?',
             form: '=',
         },
         link: function(scope, element, attrs, ngModel) {
@@ -25,9 +25,8 @@ angular.module('ddsApp').directive('montantRessource', function(SituationService
             scope.currentMonth = moment(scope.dateDeValeur).format('MMMM YYYY');
             scope.isNumber = angular.isNumber;
 
-
-            if (! scope.interruptedLabel) {
-                scope.interruptedLabel = 'Je ne percevrai plus ' + getFormattedLabel(scope.ressourceType.label) + ' en ' + scope.currentMonth;
+            if (! scope.onGoingLabel) {
+                scope.onGoingLabel = 'Je continuerai à percevoir cette ressource en ' + scope.currentMonth;
             }
 
             function checkSumConsistency() {

--- a/app/js/directives/captureMontantRessource.js
+++ b/app/js/directives/captureMontantRessource.js
@@ -3,12 +3,12 @@
 angular.module('ddsApp').directive('montantRessource', function(SituationService) {
     function getOnGoingQuestion (individu, ressource, currentMonth) {
         var subject = {
-            'demandeur': 'Je',
+            'demandeur': 'Vous',
             'conjoint': 'Votre conjoint',
             'enfant': individu.firstName
         }[individu.role],
             verbPrefix = ressource.id == 'pensionsAlimentairesVersees' ? 'verser' : 'percevr',
-            verbSufix = individu.role == 'demandeur' ? 'ai' : 'a',
+            verbSufix = individu.role == 'demandeur' ? 'ez' : 'a',
             ressourceLabel = ressource.interuptionQuestionLabel || ressource.prefix + ' ' + ressource.label.slice(0,1).toLowerCase() + ressource.label.slice(1);
 
         return [subject, verbPrefix + verbSufix, ressourceLabel, 'en', currentMonth].join(' ') + '.';

--- a/app/js/directives/captureMontantRessource.js
+++ b/app/js/directives/captureMontantRessource.js
@@ -2,7 +2,7 @@
 
 angular.module('ddsApp').directive('montantRessource', function(SituationService) {
     function getFormattedLabel (ressource) {
-        return ressource.prefix + ' ' + ressource.label.slice(0,1).toLowerCase() + ressource.label.slice(1);
+        return ressource.interuptionQuestionLabel || ressource.prefix + ' ' + ressource.label.slice(0,1).toLowerCase() + ressource.label.slice(1);
     }
 
     return {

--- a/app/js/services/ressourceService.js
+++ b/app/js/services/ressourceService.js
@@ -29,7 +29,7 @@ angular.module('ddsApp').factory('RessourceService', function() {
                 individu.ressourcesYearlyApproximation[ressource.type.id] = ressource.montantAnnuel;
             }
 
-            if (ressource.interrupted) {
+            if (! ressource.onGoing) {
                 individu.interruptedRessources.push(ressource.type.id);
             }
         },

--- a/app/views/partials/foyer/capture-montant-ressource.html
+++ b/app/views/partials/foyer/capture-montant-ressource.html
@@ -58,8 +58,8 @@
         <label>
           <input
             type="checkbox"
-            ng-model="ressource.interrupted">
-            {{ interruptedLabel }}
+            ng-model="ressource.onGoing">
+            {{ onGoingLabel }}
         </label>
       </div>
     </div>

--- a/app/views/partials/foyer/pensions-alimentaires.html
+++ b/app/views/partials/foyer/pensions-alimentaires.html
@@ -17,11 +17,10 @@
       <montant-ressource
         ng-repeat="individuVM in individusVM"
         ng-model="individuVM.pensionsVersees"
-        short-label="individuVM.label"
+        individu-v-m="individuVM"
         ressource-type="pensionsVersees"
         index="$index"
-        date-de-valeur="situation.dateDeValeur"
-        on-going-label="'Je continuerai à verser cette pension en ' + currentMonth">
+        date-de-valeur="situation.dateDeValeur">
       </montant-ressource>
     </div>
 

--- a/app/views/partials/foyer/ressources/montants.html
+++ b/app/views/partials/foyer/ressources/montants.html
@@ -77,8 +77,8 @@
         <div class="checkbox">
           <label>
             <input
-              type="checkbox" ng-model="ressource.interrupted">
-              {{ interruptedLabel }}
+              type="checkbox" ng-model="ressource.onGoing">
+              {{ onGoingLabel }}
           </label>
         </div>
       </div>

--- a/app/views/partials/foyer/ressources/montants.html
+++ b/app/views/partials/foyer/ressources/montants.html
@@ -2,7 +2,7 @@
   <div ng-if="ressource.type.category !== 'rpns'">
     <montant-ressource
       ng-model="ressource"
-      short-label="individuVM.label"
+      individu-v-m="individuVM"
       ressource-type="ressource.type"
       index="individuIndex"
       date-de-valeur="situation.dateDeValeur"
@@ -78,7 +78,7 @@
           <label>
             <input
               type="checkbox" ng-model="ressource.onGoing">
-              {{ onGoingLabel }}
+              {{ autoEntrepreneurOnGoingQuestion(individuVM.individu, currentMonth) }}
           </label>
         </div>
       </div>

--- a/app/views/partials/foyer/ressources/types.html
+++ b/app/views/partials/foyer/ressources/types.html
@@ -16,7 +16,7 @@
           <button
             type="button"
             class="btn btn-sm btn-selection btn-default"
-            ng-repeat="ressourceType in ressourceTypesByCategories[category.id]"
+            ng-repeat="ressourceType in ressourceTypesByCategories[category.id]| orderBy:['positionInList','label']"
             btn-checkbox
             ng-model="individuVM.selectedRessourceTypes[ressourceType.id]">
             {{ ressourceType.label }}

--- a/test/spec/controllers/foyer/ressources/ressources.js
+++ b/test/spec/controllers/foyer/ressources/ressources.js
@@ -160,7 +160,7 @@ describe('Controller: FoyerRessourcesCtrl', function() {
         });
 
 
-        it('should map the "interrupted" attribute of each ressource', function() {
+        it('should map the "ongoing" attribute of each ressource', function() {
             // given
             _ressourceTypes_ = [{ id: 'foo' }, { id: 'bar' }];
             scope.situation.individus = [{
@@ -178,9 +178,9 @@ describe('Controller: FoyerRessourcesCtrl', function() {
             // then
             var ressources = scope.individusVM[0].ressources;
             expect(ressources[0].type.id).toBe('foo');
-            expect(ressources[0].interrupted).toBe(true);
+            expect(ressources[0].onGoing).toBe(false);
             expect(ressources[1].type.id).toBe('bar');
-            expect(ressources[1].interrupted).toBe(false);
+            expect(ressources[1].onGoing).toBe(true);
         });
     });
 
@@ -256,8 +256,8 @@ describe('Controller: FoyerRessourcesCtrl', function() {
                 {
                     individu: individu,
                     ressources: [
-                        { type: { id: 'test' }, montantsMensuels: [], interrupted: false },
-                        { type: { id: 'test2' }, montantsMensuels: [], interrupted: true }
+                        { type: { id: 'test' }, montantsMensuels: [], onGoing: true },
+                        { type: { id: 'test2' }, montantsMensuels: [], onGoing: false }
                     ]
                 }
             ];


### PR DESCRIPTION
Follows user feedback on April 4th.

Improves neutralisation conditions for RSA (only when no substitution income).

Also sort resources alphabetically (user + CAF feedback)