### PR TITLE
Use forever in prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Once you have Node and npm installed, run:
 npm install --global grunt-cli bower
 ```
 
+### In production
+
+[foreverjs](https://github.com/foreverjs/forever) is used to run the server in production. It needs to be installed before running the deployment script.
 
 Application
 -----------
@@ -147,6 +150,7 @@ ssh openfisca-mes-aides@sgmap.fr ./deploy
 ### Déployer une feature branch
 
 #### Ajouter un utilisateur capable de déployer sur le serveur de production
+> La taille du nom d'utilisateur étant limitée à 32 caractères sur le serveur de production, le nom de la feature branch ne doit pas dépasser 22 caractères.
 
 En se connectant en tant que `root`.
 
@@ -170,6 +174,6 @@ chmod u+x /home/mes-aides-$BRANCH/deploy.sh
 
 ```sh
 ssh-add ~/.ssh/mes-aides-bot
-ssh mes-aides-$BRANCH@sgmap.fr "PORT=8200 OPENFISCA_PORT=12200 ./deploy.sh $BRANCH"
+ssh mes-aides-$BRANCH@sgmap.fr "PORT=8200 OPENFISCA_PORT=12200 ./deploy.sh"
 ssh root@sgmap.fr "service nginx reload"
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install --global grunt-cli bower
 
 [upstart](http://upstart.ubuntu.com/index.html) and [foreman](http://theforeman.org/) are used to run the production server for [mes-aides.gouv.fr](https://mes-aides.gouv.fr/).
 
-[foreverjs](https://github.com/foreverjs/forever) is used to run the server for staging feature branche versions of mes-aides. It needs to be installed before running the deployment scripts.
+[foreverjs](https://github.com/foreverjs/forever) is used to run the server for staging feature branches versions of mes-aides. It needs to be installed before running the deployment scripts.
 
 The production Mongo server can be (re)started with `ssh root@sgmap.fr "service mongod (re)start"`.
 

--- a/README.md
+++ b/README.md
@@ -181,3 +181,9 @@ ssh-add ~/.ssh/mes-aides-bot
 ssh mes-aides-$BRANCH@sgmap.fr "PORT=8200 OPENFISCA_PORT=12200 ./deploy.sh"
 ssh root@sgmap.fr "service nginx reload"
 ```
+
+### Supprimer une instance de feature branche
+```sh
+ssh mes-aides-$BRANCH@sgmap.fr 'forever stopall; rm /etc/nginx/conf.d/$(whoami).conf'
+ssh root@sgmap.fr "userdel mes-aides-$BRANCH"
+```

--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ ssh root@sgmap.fr "service nginx reload"
 ssh mes-aides-$BRANCH@sgmap.fr "./deploy.sh"
 ```
 
-### Supprimer une instance de feature branche
+### Supprimer une instance de feature branch
+
 ```sh
 ssh mes-aides-$BRANCH@sgmap.fr 'forever stopall; rm /etc/nginx/conf.d/$(whoami).conf'
 ssh root@sgmap.fr "userdel mes-aides-$BRANCH --remove"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ npm install --global grunt-cli bower
 
 ### In production
 
-[foreverjs](https://github.com/foreverjs/forever) is used to run the server in production. It needs to be installed before running the deployment script.
+[upstart](http://upstart.ubuntu.com/index.html) and [foreman](http://theforeman.org/) are used to run the production server for [mes-aides.gouv.fr](https://mes-aides.gouv.fr/).
+
+[foreverjs](https://github.com/foreverjs/forever) is used to run the server for staging feature branche versions of mes-aides. It needs to be installed before running the deployment scripts.
+
+The production Mongo server can be (re)started with `ssh root@sgmap.fr "service mongod (re)start"`.
 
 Application
 -----------

--- a/README.md
+++ b/README.md
@@ -153,8 +153,12 @@ ssh openfisca-mes-aides@sgmap.fr ./deploy
 
 ### Déployer une feature branch
 
-#### Ajouter un utilisateur capable de déployer sur le serveur de production
+Chaque feature branch est déployée sur le serveur de production par un utilisateur spécifique `mes-aides-$BRANCH`. Lorsque cet utilisateur exécute le script de déploiement `deploy.sh`, les branches `$BRANCH` de mes-aides-ui et [openfisca](https://github.com/sgmap/openfisca) sont déployées. Si cette branche n'existe pas sur le dépôt openfisca, la branche `master` est déployée.
+
 > La taille du nom d'utilisateur étant limitée à 32 caractères sur le serveur de production, le nom de la feature branch ne doit pas dépasser 22 caractères.
+
+
+#### Ajouter un utilisateur capable de déployer sur le serveur de production
 
 En se connectant en tant que `root`.
 
@@ -176,10 +180,16 @@ chmod u+x /home/mes-aides-$BRANCH/deploy.sh
 
 #### Sur le poste de développement
 
+- Premier déploiement
 ```sh
 ssh-add ~/.ssh/mes-aides-bot
 ssh mes-aides-$BRANCH@sgmap.fr "PORT=8200 OPENFISCA_PORT=12200 ./deploy.sh"
 ssh root@sgmap.fr "service nginx reload"
+```
+
+- Redéploiements
+```sh
+ssh mes-aides-$BRANCH@sgmap.fr "./deploy.sh"
 ```
 
 ### Supprimer une instance de feature branche

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install --global grunt-cli bower
 
 [upstart](http://upstart.ubuntu.com/index.html) and [foreman](http://theforeman.org/) are used to run the production server for [mes-aides.gouv.fr](https://mes-aides.gouv.fr/).
 
-[foreverjs](https://github.com/foreverjs/forever) is used to run the server for staging feature branches versions of mes-aides. It needs to be installed before running the deployment scripts.
+[foreverjs](https://github.com/foreverjs/forever) is used to run the server for staging feature branches versions of mes-aides. It needs to be installed before running the deployment scripts: `npm install --global forever`.
 
 The production Mongo server can be (re)started with `ssh root@sgmap.fr "service mongod (re)start"`.
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ En se connectant en tant que `root`.
 BRANCH=ppa
 
 # Créer l'utilisateur
-adduser mes-aides-$BRANCH  # give whichever password and leave everything to default
-passwd --delete mes-aides-$BRANCH
+adduser mes-aides-$BRANCH --disabled-password --gecos ""
 
 # Rendre l'utilisateur accessible depuis l'extérieur
 mkdir /home/mes-aides-$BRANCH/.ssh/

--- a/README.md
+++ b/README.md
@@ -195,5 +195,5 @@ ssh mes-aides-$BRANCH@sgmap.fr "./deploy.sh"
 ### Supprimer une instance de feature branche
 ```sh
 ssh mes-aides-$BRANCH@sgmap.fr 'forever stopall; rm /etc/nginx/conf.d/$(whoami).conf'
-ssh root@sgmap.fr "userdel mes-aides-$BRANCH"
+ssh root@sgmap.fr "userdel mes-aides-$BRANCH --remove"
 ```

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,13 +13,13 @@ LOG_FILE=deployment.log
 #   PORT=8000 OPENFISCA_PORT=2000 PUBLIC_HOST=mes-aides.gouv.fr PROTOCOL=https ./deploy.sh
 USER=`whoami`
 TARGET_BRANCH=${USER#mes-aides-}
-source current_config || echo "No current_config file found."
+source current_config.env || echo "No current_config.env file found."
 PORT=${PORT:-$CURRENT_PORT}
 OPENFISCA_PORT=${OPENFISCA_PORT:-$CURRENT_OPENFISCA_PORT}
 
 if ! [[ -n $PORT && -n $OPENFISCA_PORT ]]
 then
-    echo "Ports not specified, and not found in current_config file. Please provide them."; exit
+    echo "Ports not specified, and not found in current_config.env file. Please provide them."; exit
 fi
 
 PUBLIC_HOST=${PUBLIC_HOST:-${CURRENT_PUBLIC_HOST:-$TARGET_BRANCH.mes-aides.sgmap.fr}}
@@ -118,7 +118,7 @@ echo "CURRENT_PORT=$PORT
 CURRENT_OPENFISCA_PORT=$OPENFISCA_PORT
 CURRENT_PUBLIC_HOST=$PUBLIC_HOST
 CURRENT_PROTOCOL=$PROTOCOL
-" > current_config
+" > current_config.env
 
 set +x
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -41,12 +41,12 @@ npm install
 grunt build
 
 # Stop Mes Aides
-forever stop server.js || echo 'No server was running'
+forever stop mes-aides || echo 'No server was running'
 
 mongo localhost --eval "db.copyDatabase('mes-aides-master', '$USER')"
 
 # Start Mes Aides
-OPENFISCA_URL="http://localhost:$OPENFISCA_PORT" SESSION_SECRET=foobar NODE_ENV=production MES_AIDES_ROOT_URL="$PROTOCOL://$PUBLIC_HOST" PORT=$PORT MONGODB_URL="mongodb://localhost/$USER" forever -l ../mes-aides.log -e ../mes-aides_error.log --append start server.js
+OPENFISCA_URL="http://localhost:$OPENFISCA_PORT" SESSION_SECRET=foobar NODE_ENV=production MES_AIDES_ROOT_URL="$PROTOCOL://$PUBLIC_HOST" PORT=$PORT MONGODB_URL="mongodb://localhost/$USER" forever --uid mes-aides -l ../mes-aides.log -e ../mes-aides_error.log --append start server.js
 
 cd ..
 
@@ -64,12 +64,12 @@ fi
 
 # Stop OpenFisca
 {
-    forever stop start.sh
+    forever stop openfisca
     killall --user $USER $(which python)
 } || echo 'No OpenFisca server was running'
 
 # Start OpenFisca
-PORT=$OPENFISCA_PORT forever -l ../openfisca.log -e ../openfisca_error.log --append -c bash start ./start.sh mes-aides
+PORT=$OPENFISCA_PORT forever --uid openfisca -l ../openfisca.log -e ../openfisca_error.log --append -c bash start ./start.sh mes-aides
 cd ..
 
 # Set up reverse proxy

--- a/deploy.sh
+++ b/deploy.sh
@@ -57,10 +57,11 @@ then
     cd openfisca
 fi
 
-./update.sh $TARGET_BRANCH || {
-        echo "No branch $TARGET_BRANCH was found on sgmap/openfisca. Staying on current branch."
-        ./update.sh
-    }
+if ! ./update.sh $TARGET_BRANCH
+then
+    echo "No branch $TARGET_BRANCH was found on sgmap/openfisca. Staying on current branch."
+    ./update.sh
+fi
 
 # Stop OpenFisca
 {

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,11 +8,11 @@ LOG_FILE=deployment.log
 
 # Defaults for production.
 # Example for development:
-#   PORT=8100 OPENFISCA_PORT=12100 ./deploy.sh aah
+#   PORT=8100 OPENFISCA_PORT=12100 ./deploy.sh
 # Example for production:
 #   PORT=8000 OPENFISCA_PORT=2000 PUBLIC_HOST=mes-aides.gouv.fr PROTOCOL=https ./deploy.sh
 USER=`whoami`
-TARGET_BRANCH=${1:-${USER##mes-aides-}}
+TARGET_BRANCH=${USER#mes-aides-}
 PORT=${PORT:-8000}
 OPENFISCA_PORT=${OPENFISCA_PORT:-12000}
 PUBLIC_HOST=${PUBLIC_HOST:-$TARGET_BRANCH.mes-aides.sgmap.fr}

--- a/deploy.sh
+++ b/deploy.sh
@@ -43,10 +43,10 @@ grunt build
 # Stop Mes Aides
 forever stop server.js || echo 'No server was running'
 
-mongo localhost --eval "db.copyDatabase('mes-aides-master', '`whoami`')"
+mongo localhost --eval "db.copyDatabase('mes-aides-master', '$USER')"
 
 # Start Mes Aides
-OPENFISCA_URL="http://localhost:$OPENFISCA_PORT" SESSION_SECRET=foobar NODE_ENV=production MES_AIDES_ROOT_URL="$PROTOCOL://$PUBLIC_HOST" PORT=$PORT MONGODB_URL="mongodb://localhost/$(whoami)" forever -l ../mes-aides.log -e ../mes-aides_error.log --append start server.js
+OPENFISCA_URL="http://localhost:$OPENFISCA_PORT" SESSION_SECRET=foobar NODE_ENV=production MES_AIDES_ROOT_URL="$PROTOCOL://$PUBLIC_HOST" PORT=$PORT MONGODB_URL="mongodb://localhost/$USER" forever -l ../mes-aides.log -e ../mes-aides_error.log --append start server.js
 
 cd ..
 
@@ -63,7 +63,7 @@ fi
     }
 
 # Stop OpenFisca
-killall --user `whoami` /usr/bin/python || echo 'No OpenFisca server was running'
+killall --user $USER /usr/bin/python || echo 'No OpenFisca server was running'
 # Start OpenFisca
 PORT=$OPENFISCA_PORT nohup ./start.sh mes-aides >> ../openfisca.log 2>> ../openfisca_error.log &
 
@@ -71,7 +71,7 @@ cd ..
 
 # Set up reverse proxy
 
-echo "upstream $(whoami) {
+echo "upstream $USER {
     server 127.0.0.1:$PORT;
 }
 
@@ -99,10 +99,10 @@ server {
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection \"upgrade\";
 
-        proxy_pass  http://$(whoami);
+        proxy_pass  http://$USER;
         proxy_redirect off;
     }
-}" > /etc/nginx/conf.d/$(whoami).conf
+}" > /etc/nginx/conf.d/$USER.conf
 
 set +x
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,7 +23,7 @@ then
     exit 1
 fi
 
-PUBLIC_HOST=${PUBLIC_HOST:-${CURRENT_PUBLIC_HOST:-$TARGET_BRANCH.mes-aides.sgmap.fr}}
+PUBLIC_HOST=${PUBLIC_HOST:-${CURRENT_PUBLIC_HOST:-$TARGET_BRANCH.mes-aides.beta.gouv.fr}}
 PROTOCOL=${PROTOCOL:-${CURRENT_PROTOCOL:-http}}
 
 # Log deployment

--- a/deploy.sh
+++ b/deploy.sh
@@ -70,7 +70,7 @@ then
     ./update.sh
 fi
 
-PORT=$OPENFISCA_PORT ./generateConfig.sh mes-aides
+PORT=$OPENFISCA_PORT ./generateMesAidesConfig.sh
 
 # Stop OpenFisca
 forever stop openfisca || echo 'No OpenFisca server was running'

--- a/deploy.sh
+++ b/deploy.sh
@@ -76,7 +76,7 @@ PORT=$OPENFISCA_PORT ./generateConfig.sh mes-aides
 forever stop openfisca || echo 'No OpenFisca server was running'
 
 # Start OpenFisca
-forever --uid openfisca -l ../openfisca.log -e ../openfisca_error.log --append -c paster serve config/current.ini
+forever --uid openfisca -l ../openfisca.log -e ../openfisca_error.log --append start -c "paster serve" config/current.ini
 cd ..
 
 # Set up reverse proxy

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,7 +19,7 @@ OPENFISCA_PORT=${OPENFISCA_PORT:-$CURRENT_OPENFISCA_PORT}
 
 if ! [[ -n $PORT && -n $OPENFISCA_PORT ]]
 then
-    echo "Ports not specified, and not found in current_config file. Please provide them."
+    echo "Ports not specified, and not found in current_config file. Please provide them."; exit
 fi
 
 PUBLIC_HOST=${PUBLIC_HOST:-${CURRENT_PUBLIC_HOST:-$TARGET_BRANCH.mes-aides.sgmap.fr}}

--- a/deploy.sh
+++ b/deploy.sh
@@ -63,10 +63,13 @@ fi
     }
 
 # Stop OpenFisca
-killall --user $USER /usr/bin/python || echo 'No OpenFisca server was running'
-# Start OpenFisca
-PORT=$OPENFISCA_PORT nohup ./start.sh mes-aides >> ../openfisca.log 2>> ../openfisca_error.log &
+{
+    forever stop start.sh
+    killall --user $USER $(which python)
+} || echo 'No OpenFisca server was running'
 
+# Start OpenFisca
+PORT=$OPENFISCA_PORT forever -l ../openfisca.log -e ../openfisca_error.log --append -c bash start ./start.sh mes-aides
 cd ..
 
 # Set up reverse proxy

--- a/deploy.sh
+++ b/deploy.sh
@@ -131,7 +131,7 @@ wget --quiet --retry-connrefused --waitretry=1 --output-document=/dev/null http:
 # Smoke test
 curl -sL -w "GET %{url_effective} -> %{http_code}\\n" localhost:$OPENFISCA_PORT -o /dev/null
 curl -sL -w "GET %{url_effective} -> %{http_code}\\n" localhost:$PORT -o /dev/null
-curl -sL -w "GET %{url_effective} -> %{http_code}\\n" $PROTOCOL://$PUBLIC_HOST -o /dev/null
+curl -sL -w "GET %{url_effective} -> %{http_code}\\n" $PROTOCOL://$PUBLIC_HOST/foyer/demandeur -o /dev/null
 
 echo
 echo 'Exécuter `service nginx reload` en root en cas de changement de ports ou de nouvelle instance'

--- a/deploy.sh
+++ b/deploy.sh
@@ -52,11 +52,14 @@ cd ..
 # Install OpenFisca
 if ! cd openfisca
 then
-    git clone https://github.com/sgmap/openfisca.git --branch $TARGET_BRANCH
+    git clone https://github.com/sgmap/openfisca.git
     cd openfisca
 fi
 
-./update.sh $TARGET_BRANCH
+./update.sh $TARGET_BRANCH || {
+        echo "No branch $TARGET_BRANCH was found on sgmap/openfisca. Staying on current branch."
+        ./update.sh
+    }
 
 # Stop OpenFisca
 killall --user `whoami` /usr/bin/python || echo 'No OpenFisca server was running'

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,7 +19,8 @@ OPENFISCA_PORT=${OPENFISCA_PORT:-$CURRENT_OPENFISCA_PORT}
 
 if ! [[ -n $PORT && -n $OPENFISCA_PORT ]]
 then
-    echo "Ports not specified, and not found in current_config.env file. Please provide them."; exit
+    echo "Ports not specified, and not found in current_config.env file. Please provide them."
+    exit 1
 fi
 
 PUBLIC_HOST=${PUBLIC_HOST:-${CURRENT_PUBLIC_HOST:-$TARGET_BRANCH.mes-aides.sgmap.fr}}

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,18 +13,17 @@ LOG_FILE=deployment.log
 #   PORT=8000 OPENFISCA_PORT=2000 PUBLIC_HOST=mes-aides.gouv.fr PROTOCOL=https ./deploy.sh
 USER=`whoami`
 TARGET_BRANCH=${USER#mes-aides-}
+source current_config || echo "No current_config file found."
+PORT=${PORT:-$CURRENT_PORT}
+OPENFISCA_PORT=${OPENFISCA_PORT:-$CURRENT_OPENFISCA_PORT}
 
 if ! [[ -n $PORT && -n $OPENFISCA_PORT ]]
 then
-    echo "Ports were not specified. Trying to load from 'current_ports' file."
-    source current_ports
-    PORT=${PORT:-$CURRENT_PORT}
-    OPENFISCA_PORT=${OPENFISCA_PORT:-$CURRENT_OPENFISCA_PORT}
+    echo "Ports not specified, and not found in current_config file. Please provide them."
 fi
 
-PUBLIC_HOST=${PUBLIC_HOST:-$TARGET_BRANCH.mes-aides.sgmap.fr}
-PROTOCOL=${PROTOCOL:-http}
-
+PUBLIC_HOST=${PUBLIC_HOST:-${CURRENT_PUBLIC_HOST:-$TARGET_BRANCH.mes-aides.sgmap.fr}}
+PROTOCOL=${PROTOCOL:-${CURRENT_PROTOCOL:-http}}
 
 # Log deployment
 date >> $LOG_FILE
@@ -114,10 +113,12 @@ server {
     }
 }" > /etc/nginx/conf.d/$USER.conf
 
-# Save PORT numbers
+# Save current config
 echo "CURRENT_PORT=$PORT
 CURRENT_OPENFISCA_PORT=$OPENFISCA_PORT
-" > current_ports
+CURRENT_PUBLIC_HOST=$PUBLIC_HOST
+CURRENT_PROTOCOL=$PROTOCOL
+" > current_config
 
 set +x
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -63,14 +63,13 @@ then
     ./update.sh
 fi
 
+PORT=$OPENFISCA_PORT ./generateConfig.sh mes-aides
+
 # Stop OpenFisca
-{
-    forever stop openfisca
-    killall --user $USER $(which python)
-} || echo 'No OpenFisca server was running'
+forever stop openfisca || echo 'No OpenFisca server was running'
 
 # Start OpenFisca
-PORT=$OPENFISCA_PORT forever --uid openfisca -l ../openfisca.log -e ../openfisca_error.log --append -c bash start ./start.sh mes-aides
+forever --uid openfisca -l ../openfisca.log -e ../openfisca_error.log --append -c paster serve config/current.ini
 cd ..
 
 # Set up reverse proxy

--- a/deploy.sh
+++ b/deploy.sh
@@ -11,7 +11,8 @@ LOG_FILE=deployment.log
 #   PORT=8100 OPENFISCA_PORT=12100 ./deploy.sh aah
 # Example for production:
 #   PORT=8000 OPENFISCA_PORT=2000 PUBLIC_HOST=mes-aides.gouv.fr PROTOCOL=https ./deploy.sh
-TARGET_BRANCH=${1:-master}
+USER=`whoami`
+TARGET_BRANCH=${1:-${USER##mes-aides-}}
 PORT=${PORT:-8000}
 OPENFISCA_PORT=${OPENFISCA_PORT:-12000}
 PUBLIC_HOST=${PUBLIC_HOST:-$TARGET_BRANCH.mes-aides.sgmap.fr}

--- a/deploy.sh
+++ b/deploy.sh
@@ -132,7 +132,7 @@ wget --quiet --retry-connrefused --waitretry=1 --output-document=/dev/null http:
 # Smoke test
 curl -sL -w "GET %{url_effective} -> %{http_code}\\n" localhost:$OPENFISCA_PORT -o /dev/null
 curl -sL -w "GET %{url_effective} -> %{http_code}\\n" localhost:$PORT -o /dev/null
-curl -sL -w "GET %{url_effective} -> %{http_code}\\n" $PROTOCOL://$PUBLIC_HOST/foyer/demandeur -o /dev/null
+curl -sL -w "GET %{url_effective} -> %{http_code}\\n" $PROTOCOL://$PUBLIC_HOST -o /dev/null
 
 echo
 echo 'Exécuter `service nginx reload` en root en cas de changement de ports ou de nouvelle instance'

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,8 +13,15 @@ LOG_FILE=deployment.log
 #   PORT=8000 OPENFISCA_PORT=2000 PUBLIC_HOST=mes-aides.gouv.fr PROTOCOL=https ./deploy.sh
 USER=`whoami`
 TARGET_BRANCH=${USER#mes-aides-}
-PORT=${PORT:-8000}
-OPENFISCA_PORT=${OPENFISCA_PORT:-12000}
+
+if ! [[ -n $PORT && -n $OPENFISCA_PORT ]]
+then
+    echo "Ports were not specified. Trying to load from 'current_ports' file."
+    source current_ports
+    PORT=${PORT:-$CURRENT_PORT}
+    OPENFISCA_PORT=${OPENFISCA_PORT:-$CURRENT_OPENFISCA_PORT}
+fi
+
 PUBLIC_HOST=${PUBLIC_HOST:-$TARGET_BRANCH.mes-aides.sgmap.fr}
 PROTOCOL=${PROTOCOL:-http}
 
@@ -106,6 +113,11 @@ server {
         proxy_redirect off;
     }
 }" > /etc/nginx/conf.d/$USER.conf
+
+# Save PORT numbers
+echo "CURRENT_PORT=$PORT
+CURRENT_OPENFISCA_PORT=$OPENFISCA_PORT
+" > current_ports
 
 set +x
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -40,12 +40,12 @@ npm install
 grunt build
 
 # Stop Mes Aides
-killall --user `whoami` node || echo 'No server was running'
+forever stop server.js || echo 'No server was running'
 
 mongo localhost --eval "db.copyDatabase('mes-aides-master', '`whoami`')"
 
 # Start Mes Aides
-OPENFISCA_URL="http://localhost:$OPENFISCA_PORT" SESSION_SECRET=foobar NODE_ENV=production MES_AIDES_ROOT_URL="$PROTOCOL://$PUBLIC_HOST" PORT=$PORT MONGODB_URL="mongodb://localhost/$(whoami)" nohup node server.js >> ../mes-aides.log 2>> ../mes-aides_error.log &
+OPENFISCA_URL="http://localhost:$OPENFISCA_PORT" SESSION_SECRET=foobar NODE_ENV=production MES_AIDES_ROOT_URL="$PROTOCOL://$PUBLIC_HOST" PORT=$PORT MONGODB_URL="mongodb://localhost/$(whoami)" forever -l ../mes-aides.log -e ../mes-aides_error.log --append start server.js
 
 cd ..
 


### PR DESCRIPTION
The goal is to make the feature branch deployment process more robust, so that we can use it in real prod as well.

To do:
- [x] Explicit dependency to forever in Readme
- [x] Disable openfisca live-reload in production mode
- [x] Explicit how to restart mongo if it crashes
- [ ] ~~Include to script prod specific nginx configuration (ssl, etc.)~~
- [ ] Make nginx serve a 404 for random addresses

Fixes sgmap/beta.gouv.fr#105.