### PR TITLE
Ajout de la question "utiliser mon numéro fiscal" dans la FAQ

### DIFF
--- a/app/views/partials/faq.html
+++ b/app/views/partials/faq.html
@@ -17,6 +17,11 @@
   <h3>Qu’est ce qui est fait des informations renseignées dans le cadre d’une simulation ?</h3>
   <p>Toute simulation est anonyme. Mes Aides ne stocke aucune information personnelle.</p>
 
+  <h3 id="nir">Pourquoi ne suffit-il pas d'entrer mon numéro fiscal et mon numéro de sécurité sociale pour évaluer mes droits ?</h3>
+  <p>Nous considérons évidemment cette possibilité. Saviez-vous qu’elle devient de plus en plus réaliste au fur et à mesure que des outils comme <a href="http://api.beta.gouv.fr/api/franceconnect.html">FranceConnect</a> ou <a href="http://api.beta.gouv.fr/api/api-particulier.html">API Particulier</a> gagnent en maturité ?</p>
+  <p>Cependant, nos tests auprès d’utilisateurs prouvent qu’un simulateur ne nécessitant pas d’identifiants reste une nécessité. En effet, quasiment toute personne connaît sa situation familiale, son loyer et ses revenus approximatifs. On ne peut pas en dire autant de son numéro de sécurité sociale, moins encore de son numéro fiscal !</p>
+  <p>Rappelons également que Mes Aides est un simulateur. Cette application vous permet donc de simuler des situations qui ne correspondent pas forcément à la vôtre, comme celle d’un proche, ou encore celles dans lesquelles vous pourriez vous trouver si vous déménagiez ou changiez de situation professionnelle, par exemple.</p>
+
   <h3>Comment contribuer à l’amélioration du simulateur ?</h3>
   <p>L’équipe Mes Aides est à l’écoute de tous vos retours. Vous pouvez nous écrire à l’adresse contribuer@mes-aides.gouv.fr. Si vous obtenez un résultat inattendu de la part du simulateur, vous pouvez nous en faire part en enregistrant le cas en fin de simulation. Nous vous créerons un compte pour que vous puissiez contribuer sur notre plateforme de tests.</p>
 

--- a/app/views/partials/faq.html
+++ b/app/views/partials/faq.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <h1>FAQ</h1>
+  <h1>Foire Aux Questions</h1>
 
   <h3>Quelles sont les prestations sociales disponibles sur mes-aides.gouv.fr ?</h3>
   <p>Le Revenu de Solidarité Active (RSA) socle et activité, l'Allocation Spécifique de Solidarité (ASS), la Couverture Médicale Universelle Complémentaire (CMU-c), l'Aide à la Complémentaire Santé (ACS), l'Allocation de Solidarité aux Personnes Âgées (ASPA), l'Allocation Supplémentaire d'Invalidité (ASI), les Prestations Familiales (Allocation Familiale, Allocation Soutien Familial, Complément Familial, Allocation de base de la Prestation d'Accueil du Jeune Enfant), les Allocations Logement (Allocation de Logement Sociale, Allocation de Logement Familiale, Aide Personnalisée au Logement), les bourses de l’Education Nationale (collège et lycée), l’aide Paris Logement Famille de la ville de Paris, l’Aide départementale pour les personnes âgées du 93.</p>


### PR DESCRIPTION
> Pourquoi ne suffit-il pas d'entrer mon numéro fiscal et mon numéro de sécurité sociale pour évaluer mes droits ?