### PR TITLE
Ajoute le code de suivi pour l'étude d'impact Pôle Emploi

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -188,7 +188,7 @@ ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $u
         });
 });
 
-ddsApp.run(function($rootScope, $state, $stateParams, $window, $modalStack, $anchorScroll) {
+ddsApp.run(function($rootScope, $state, $stateParams, $window, $modalStack, $anchorScroll, ImpactStudyService) {
     $rootScope.$state = $state;
     $rootScope.$stateParams = $stateParams;
 
@@ -216,5 +216,7 @@ ddsApp.run(function($rootScope, $state, $stateParams, $window, $modalStack, $anc
             $window._paq.push(['setCustomUrl', current]);
             $window._paq.push(['trackPageView']);
         }
+
+        ImpactStudyService.sendVisitedPage();
     });
 });

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var ddsApp = angular.module('ddsApp', ['ui.router', 'ngAnimate', 'ddsCommon', 'ngSanitize']);
+var ddsApp = angular.module('ddsApp', ['ui.router', 'ngAnimate', 'ddsCommon', 'ngSanitize', 'angular-uuid']);
 
 ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $uiViewScrollProvider) {
     moment.lang('fr');

--- a/app/js/controllers/foyer/logement.js
+++ b/app/js/controllers/foyer/logement.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http, $log, logementTypes, locationTypes, loyerLabels) {
+angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http, $log, logementTypes, locationTypes, loyerLabels, ImpactStudyService) {
     var logement = $scope.logement = {
         adresse: {},
         inhabitantForThreeYearsOutOfLastFive: true
@@ -103,6 +103,7 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
         if (form.$valid && logement.adresse) {
             logement.inhabitantForThreeYearsOutOfLastFive = logement.inhabitantForThreeYearsOutOfLastFive && cityStartsWith('Paris');
             $scope.$emit('logement', logement);
+            ImpactStudyService.sendPostCode($scope.situation);
         }
     };
 });

--- a/app/js/controllers/resultat.js
+++ b/app/js/controllers/resultat.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('ddsApp').controller('ResultatCtrl', function($scope, $rootScope, $window, $http, $state, $stateParams, $timeout, SituationService, ResultatService, cerfaForms, droitsDescription) {
+angular.module('ddsApp').controller('ResultatCtrl', function($scope, $rootScope, $window, $http, $state, $stateParams, $timeout, SituationService, ResultatService, ImpactStudyService, cerfaForms, droitsDescription) {
     $scope.yearMoins2 = moment($scope.situation.dateDeValeur).subtract('years', 2).format('YYYY');
     $scope.debutPeriode = moment($scope.situation.dateDeValeur).startOf('month').subtract('years', 1).format('MMMM YYYY');
     $scope.finPeriode = moment($scope.situation.dateDeValeur).startOf('month').subtract('months', 1).format('MMMM YYYY');
@@ -17,6 +17,8 @@ angular.module('ddsApp').controller('ResultatCtrl', function($scope, $rootScope,
         $scope.noDroits = _.isEmpty($scope.droits);
     }, function() {
         $scope.error = true;
+    }).then(function() {
+        ImpactStudyService.sendResults($scope.situation, $scope.droits);
     }).finally(function() {
         $scope.awaitingResults = false;
     });

--- a/app/js/services/impactStudyService.js
+++ b/app/js/services/impactStudyService.js
@@ -1,8 +1,7 @@
 'use strict';
 
 angular.module('ddsApp').service('ImpactStudyService', function($location, $http, $sessionStorage, $log, uuid) {
-    var RESEARCH_DOMAIN = 'https://mes-droits.fr',  // this domain is owned by economy researchers mandated by Pole Emploi and DGCS
-        STUDIED_PRESTATIONS = [ 'aah', 'aah_non_calculable', 'acs', 'adpa', 'af', 'aide_logement', 'aide_logement_non_calculable', 'alf', 'als', 'apl', 'asf', 'asi', 'aspa', 'ass', 'bourse_college', 'bourse_lycee', 'cf', 'cmu_c', 'paje_base', 'paris_logement_familles', 'ppa', 'rsa', 'rsa_majore', 'rsa_non_calculable', 'rsa_non_majore' ];
+    var RESEARCH_DOMAIN = 'https://mes-droits.fr';  // this domain is owned by economy researchers mandated by Pole Emploi and DGCS
 
 
     function getSessionId() {
@@ -13,16 +12,6 @@ angular.module('ddsApp').service('ImpactStudyService', function($location, $http
     function getResearchId() {
         $sessionStorage.researchId = $sessionStorage.researchId || $location.search().eid;
         return $sessionStorage.researchId;
-    }
-
-    function extractStudiedResults(openfiscaResults) {
-        var result = {};
-
-        STUDIED_PRESTATIONS.forEach(function(id) {
-            result[id] = openfiscaResults[id];
-        });
-
-        return result;
     }
 
     function send(path, payload) {
@@ -40,7 +29,7 @@ angular.module('ddsApp').service('ImpactStudyService', function($location, $http
 
     return {
         sendResults: function(situation, openfiscaResults) {
-            var payload = extractStudiedResults(openfiscaResults);
+            var payload = angular.copy(openfiscaResults);
             payload.postcode = situation.logement.adresse.codePostal;
 
             send('/sr', payload);

--- a/app/js/services/impactStudyService.js
+++ b/app/js/services/impactStudyService.js
@@ -2,6 +2,8 @@
 
 angular.module('ddsApp').service('ImpactStudyService', function($http, $sessionStorage) {
 
+    var ENDPOINT = 'https://mes-droits.fr/sr';
+
     function getSessionId() {
             $sessionStorage.sessionId = $sessionStorage.sessionId ? $sessionStorage.sessionId : uuid.v1();
             return $sessionStorage.sessionId;
@@ -16,6 +18,20 @@ angular.module('ddsApp').service('ImpactStudyService', function($http, $sessionS
             delete openfiscaResults['paris_logement_aspeh'];
             delete openfiscaResults['paris_logement_plfm'];
             delete openfiscaResults['paris_logement_psol'];
+
+            var result = _.merge(openfiscaResults, {
+                'session_id' : getSessionId(),
+                'eid': eid,
+                'postCode': situation.logement.adresse.codePostal
+            });
+
+            $http.post(ENDPOINT, result).success(function(data) {
+               console.log("Results transmitted to the Survey API");
+               console.log(data);
+            }).error(function(error) {
+                console.log("Error while transmitting results to the Survey API");
+                console.log(error);
+            });
         }
     };
 });

--- a/app/js/services/impactStudyService.js
+++ b/app/js/services/impactStudyService.js
@@ -1,37 +1,58 @@
 'use strict';
 
-angular.module('ddsApp').service('ImpactStudyService', function($http, $sessionStorage) {
+angular.module('ddsApp').service('ImpactStudyService', function($location, $http, $sessionStorage, $log, uuid) {
+    var RESEARCH_DOMAIN = 'https://mes-droits.fr',  // this domain is owned by economy researchers mandated by Pole Emploi and DGCS
+        STUDIED_PRESTATIONS = [ 'aah', 'aah_non_calculable', 'acs', 'adpa', 'af', 'aide_logement', 'aide_logement_non_calculable', 'alf', 'als', 'apl', 'asf', 'asi', 'aspa', 'ass', 'bourse_college', 'bourse_lycee', 'cf', 'cmu_c', 'paje_base', 'paris_logement_familles', 'ppa', 'rsa', 'rsa_majore', 'rsa_non_calculable', 'rsa_non_majore' ];
 
-    var ENDPOINT = 'https://mes-droits.fr/sr';
 
     function getSessionId() {
-            $sessionStorage.sessionId = $sessionStorage.sessionId ? $sessionStorage.sessionId : uuid.v1();
-            return $sessionStorage.sessionId;
+        $sessionStorage.sessionId = $sessionStorage.sessionId || uuid.v4();
+        return $sessionStorage.sessionId;
+    }
+
+    function getResearchId() {
+        $sessionStorage.researchId = $sessionStorage.researchId || $location.search().eid;
+        return $sessionStorage.researchId;
+    }
+
+    function extractStudiedResults(openfiscaResults) {
+        var result = {};
+
+        STUDIED_PRESTATIONS.forEach(function(id) {
+            result[id] = openfiscaResults[id];
+        });
+
+        return result;
+    }
+
+    function send(path, payload) {
+        if (! getResearchId())
+            return;  // this research is based on controlled cohorts; track only users that have a valid research ID opt-in
+
+        /*jshint camelcase: false */
+        payload.session_id = getSessionId();
+        payload.eid = getResearchId();
+
+        $http.post(RESEARCH_DOMAIN + path, payload)
+             .success(function(res) { $log.info('Data transmitted to researchers', res); })
+             .error(function(error) { $log.warn('Data could not be transmitted to researchers', error); });
     }
 
     return {
-        sendResults: function(eid, situation, openfiscaResults) {
-            delete openfiscaResults['paris_complement_sante'];
-            delete openfiscaResults['paris_energie_famille'];
-            delete openfiscaResults['paris_forfait_famille'];
-            delete openfiscaResults['paris_logement'];
-            delete openfiscaResults['paris_logement_aspeh'];
-            delete openfiscaResults['paris_logement_plfm'];
-            delete openfiscaResults['paris_logement_psol'];
+        sendResults: function(situation, openfiscaResults) {
+            var payload = extractStudiedResults(openfiscaResults);
+            payload.postcode = situation.logement.adresse.codePostal;
 
-            var result = _.merge(openfiscaResults, {
-                'session_id' : getSessionId(),
-                'eid': eid,
-                'postCode': situation.logement.adresse.codePostal
-            });
+            send('/sr', payload);
+        },
 
-            $http.post(ENDPOINT, result).success(function(data) {
-               console.log("Results transmitted to the Survey API");
-               console.log(data);
-            }).error(function(error) {
-                console.log("Error while transmitting results to the Survey API");
-                console.log(error);
-            });
+        sendPostCode: function(situation) {
+            send('/cp', { postcode: situation.logement.adresse.codePostal });
+        },
+
+        sendVisitedPage: function() {
+            /*jshint camelcase: false */
+            send('/it', { url_visited: $location.absUrl() });
         }
     };
 });

--- a/app/js/services/impactStudyService.js
+++ b/app/js/services/impactStudyService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('ddsApp').service('ImpactStudyService', function($location, $http, $sessionStorage, $log, uuid) {
+angular.module('ddsApp').service('ImpactStudyService', function($location, $http, $localStorage, $sessionStorage, $log, uuid) {
     var RESEARCH_DOMAIN = 'mes-droits.fr';  // this domain is owned by Poverty Lab researchers mandated by Pole Emploi and DGCS
 
 
@@ -10,8 +10,8 @@ angular.module('ddsApp').service('ImpactStudyService', function($location, $http
     }
 
     function getResearchId() {
-        $sessionStorage.researchId = $sessionStorage.researchId || $location.search().eid;
-        return $sessionStorage.researchId;
+        $localStorage.researchId = $localStorage.researchId || $location.search().eid;
+        return $localStorage.researchId;
     }
 
     function send(path, payload) {

--- a/app/js/services/impactStudyService.js
+++ b/app/js/services/impactStudyService.js
@@ -27,7 +27,7 @@ angular.module('ddsApp').service('ImpactStudyService', function($location, $http
         payload.eid = getResearchId();
 
         $http.post('https://' + RESEARCH_DOMAIN + '/v1' + path, payload)
-             .success(function(res) { $log.info('Data transmitted to researchers', res); })
+             .success(function(res) { $log.info('Data transmitted to researchers. For more info, see ' + RESEARCH_DOMAIN, res); })
              .error(function(error) { $log.warn('Data could not be transmitted to researchers', error); });
     }
 

--- a/app/js/services/impactStudyService.js
+++ b/app/js/services/impactStudyService.js
@@ -1,0 +1,16 @@
+'use strict';
+
+angular.module('ddsApp').service('ImpactStudyService', function($http) {
+
+    return {
+        sendResults: function(eid, situation, openfiscaResults) {
+            delete openfiscaResults['paris_complement_sante'];
+            delete openfiscaResults['paris_energie_famille'];
+            delete openfiscaResults['paris_forfait_famille'];
+            delete openfiscaResults['paris_logement'];
+            delete openfiscaResults['paris_logement_aspeh'];
+            delete openfiscaResults['paris_logement_plfm'];
+            delete openfiscaResults['paris_logement_psol'];
+        }
+    };
+});

--- a/app/js/services/impactStudyService.js
+++ b/app/js/services/impactStudyService.js
@@ -9,6 +9,10 @@ angular.module('ddsApp').service('ImpactStudyService', function($location, $http
         return $sessionStorage.sessionId;
     }
 
+    function resetSessionId() {
+        $sessionStorage.sessionId = uuid.v4();
+    }
+
     function getResearchId() {
         $localStorage.researchId = $localStorage.researchId || $location.search().eid;
         return $localStorage.researchId;
@@ -42,6 +46,8 @@ angular.module('ddsApp').service('ImpactStudyService', function($location, $http
         sendVisitedPage: function() {
             /*jshint camelcase: false */
             send('/it', { url_visited: $location.absUrl() });
-        }
+        },
+
+        resetSessionId: resetSessionId
     };
 });

--- a/app/js/services/impactStudyService.js
+++ b/app/js/services/impactStudyService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('ddsApp').service('ImpactStudyService', function($location, $http, $sessionStorage, $log, uuid) {
-    var RESEARCH_DOMAIN = 'https://mes-droits.fr';  // this domain is owned by economy researchers mandated by Pole Emploi and DGCS
+    var RESEARCH_DOMAIN = 'mes-droits.fr';  // this domain is owned by Poverty Lab researchers mandated by Pole Emploi and DGCS
 
 
     function getSessionId() {
@@ -22,7 +22,7 @@ angular.module('ddsApp').service('ImpactStudyService', function($location, $http
         payload.session_id = getSessionId();
         payload.eid = getResearchId();
 
-        $http.post(RESEARCH_DOMAIN + path, payload)
+        $http.post('https://' + RESEARCH_DOMAIN + '/v1' + path, payload)
              .success(function(res) { $log.info('Data transmitted to researchers', res); })
              .error(function(error) { $log.warn('Data could not be transmitted to researchers', error); });
     }

--- a/app/js/services/impactStudyService.js
+++ b/app/js/services/impactStudyService.js
@@ -1,6 +1,11 @@
 'use strict';
 
-angular.module('ddsApp').service('ImpactStudyService', function($http) {
+angular.module('ddsApp').service('ImpactStudyService', function($http, $sessionStorage) {
+
+    function getSessionId() {
+            $sessionStorage.sessionId = $sessionStorage.sessionId ? $sessionStorage.sessionId : uuid.v1();
+            return $sessionStorage.sessionId;
+    }
 
     return {
         sendResults: function(eid, situation, openfiscaResults) {

--- a/app/js/services/resultatService.js
+++ b/app/js/services/resultatService.js
@@ -1,7 +1,6 @@
 'use strict';
 
-angular.module('ddsApp').service('ResultatService', function($http, $modal, $location, droitsDescription, ImpactStudyService) {
-
+angular.module('ddsApp').service('ResultatService', function($http, $modal, droitsDescription, ImpactStudyService) {
     function processOpenfiscaResult(openfiscaResult) {
         var droitsEligibles = {};
         var calculatedPrestations = openfiscaResult.calculatedPrestations;
@@ -39,10 +38,7 @@ angular.module('ddsApp').service('ResultatService', function($http, $modal, $loc
             return $http.get('/api/situations/' + situation._id + '/simulation', {
                 params: { cacheBust: Date.now() }
             }).then(function(response) {
-                var eid = $location.search().eid;
-                if (eid) {
-                    ImpactStudyService.sendResults(eid, situation, response.data.calculatedPrestations);
-                }
+                ImpactStudyService.sendResults(situation, response.data.calculatedPrestations);
                 return processOpenfiscaResult(response.data);
             }).catch(function(error) {
                 $modal.open({

--- a/app/js/services/resultatService.js
+++ b/app/js/services/resultatService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('ddsApp').service('ResultatService', function($http, $modal, droitsDescription, ImpactStudyService) {
+angular.module('ddsApp').service('ResultatService', function($http, $modal, droitsDescription) {
     function processOpenfiscaResult(openfiscaResult) {
         var droitsEligibles = {};
         var calculatedPrestations = openfiscaResult.calculatedPrestations;
@@ -38,7 +38,6 @@ angular.module('ddsApp').service('ResultatService', function($http, $modal, droi
             return $http.get('/api/situations/' + situation._id + '/simulation', {
                 params: { cacheBust: Date.now() }
             }).then(function(response) {
-                ImpactStudyService.sendResults(situation, response.data.calculatedPrestations);
                 return processOpenfiscaResult(response.data);
             }).catch(function(error) {
                 $modal.open({

--- a/app/js/services/resultatService.js
+++ b/app/js/services/resultatService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('ddsApp').service('ResultatService', function($http, $modal, droitsDescription) {
+angular.module('ddsApp').service('ResultatService', function($http, $modal, $location, droitsDescription, ImpactStudyService) {
 
     function processOpenfiscaResult(openfiscaResult) {
         var droitsEligibles = {};
@@ -39,6 +39,10 @@ angular.module('ddsApp').service('ResultatService', function($http, $modal, droi
             return $http.get('/api/situations/' + situation._id + '/simulation', {
                 params: { cacheBust: Date.now() }
             }).then(function(response) {
+                var eid = $location.search().eid;
+                if (eid) {
+                    ImpactStudyService.sendResults(eid, situation, response.data.calculatedPrestations);
+                }
                 return processOpenfiscaResult(response.data);
             }).catch(function(error) {
                 $modal.open({

--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('ddsCommon').factory('SituationService', function($http, $sessionStorage, $modal, categoriesRnc) {
+angular.module('ddsCommon').factory('SituationService', function($http, $sessionStorage, $modal, categoriesRnc, ImpactStudyService) {
     var situation;
 
     var flattenRessource = function(ressource, source, target) {
@@ -59,6 +59,7 @@ angular.module('ddsCommon').factory('SituationService', function($http, $session
     return {
         newSituation: function() {
             situation = $sessionStorage.situation = { individus: [], dateDeValeur: moment().format() };
+            ImpactStudyService.resetSessionId();
         },
 
         restoreLocal: function() {

--- a/app/views/front.html
+++ b/app/views/front.html
@@ -162,6 +162,7 @@
     <script src="js/services/individuService.js"></script>
     <script src="js/services/cerfaService.js"></script>
     <script src="js/services/ressourceService.js"></script>
+    <script src="js/services/impactStudyService.js"></script>
 
     <script src="js/directives/date.js"></script>
     <script src="js/directives/dateMonthYear.js"></script>

--- a/app/views/front.html
+++ b/app/views/front.html
@@ -118,11 +118,11 @@
     <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
     <script src="bower_components/angular-animate/angular-animate.js"></script>
     <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
+    <script src="bower_components/angular-uuids/angular-uuid.js"></script>
     <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
     <script src="bower_components/ngstorage/ngStorage.js"></script>
     <script src="bower_components/moment/moment.js"></script>
     <script src="bower_components/lodash/dist/lodash.compat.js"></script>
-    <script src="bower_components/node-uuid/uuid.js"></script>
     <!-- endbower -->
     <script src="bower_components/moment/lang/fr.js"></script>
     <!-- endbuild -->

--- a/app/views/front.html
+++ b/app/views/front.html
@@ -122,6 +122,7 @@
     <script src="bower_components/ngstorage/ngStorage.js"></script>
     <script src="bower_components/moment/moment.js"></script>
     <script src="bower_components/lodash/dist/lodash.compat.js"></script>
+    <script src="bower_components/node-uuid/uuid.js"></script>
     <!-- endbower -->
     <script src="bower_components/moment/lang/fr.js"></script>
     <!-- endbuild -->

--- a/bower.json
+++ b/bower.json
@@ -25,19 +25,19 @@
     "angular-sanitize": "~1.2.29",
     "angular-animate": "~1.2.29",
     "angular-ui-router": "~0.2.10",
+    "angular-uuids": "~0.0.3",
     "angular-bootstrap": "0.12.0",
     "bootstrap-sass-official": "~3.3.1",
     "ngstorage": "~0.3.0",
     "moment": "~2.7.0",
     "lodash": "~2.4.1",
-    "font-awesome": "~4.2",
-    "node-uuid": "~1.4.7"
+    "font-awesome": "~4.2"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.29"
   },
   "testPath": "test/spec",
   "resolutions": {
-    "angular": ">=1 <1.3.0"
+    "angular": "1.2.29"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,8 @@
     "ngstorage": "~0.3.0",
     "moment": "~2.7.0",
     "lodash": "~2.4.1",
-    "font-awesome": "~4.2"
+    "font-awesome": "~4.2",
+    "node-uuid": "~1.4.7"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.29"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,6 +23,7 @@ module.exports = function(config) {
       'app/bower_components/lodash/dist/lodash.compat.js',
       'app/bower_components/angular-ui-router/release/angular-ui-router.js',
       'app/bower_components/angular-bootstrap/ui-bootstrap.js',
+      'app/bower_components/angular-uuids/angular-uuid.js',
       'app/bower_components/lodash/dist/lodash.compat.js',
       'app/js/embed.js',    // depth-first glob interpretation of karma test runner means we need a forward declaration of the module
       'app/js/**/*.js',

--- a/test/spec/services/impactStudyService.js
+++ b/test/spec/services/impactStudyService.js
@@ -44,7 +44,7 @@ describe('ImpactStudyService', function() {
             location.search({ eid: EID });
             browserController.poll();
 
-            httpMock.expectPOST('https://mes-droits.fr/sr', validate);
+            httpMock.expectPOST('https://mes-droits.fr/v1/sr', validate);
             subject.sendResults(SITUATION, {});
             httpMock.flush();
         });
@@ -59,7 +59,7 @@ describe('ImpactStudyService', function() {
             location.search({ eid: EID });
             browserController.poll();
 
-            httpMock.expectPOST('https://mes-droits.fr/cp', validate);
+            httpMock.expectPOST('https://mes-droits.fr/v1/cp', validate);
             subject.sendPostCode(SITUATION);
             httpMock.flush();
         });
@@ -74,7 +74,7 @@ describe('ImpactStudyService', function() {
             location.search({ eid: EID });
             browserController.poll();
 
-            httpMock.expectPOST('https://mes-droits.fr/it');
+            httpMock.expectPOST('https://mes-droits.fr/v1/it');
             subject.sendVisitedPage();
             httpMock.flush();
         });

--- a/test/spec/services/impactStudyService.js
+++ b/test/spec/services/impactStudyService.js
@@ -4,18 +4,20 @@ describe('ImpactStudyService', function() {
     var subject,
         httpMock,
         location,
-        browserController;
+        browserController,
+        sessionStorage;
 
     var SITUATION = { logement: { adresse: { codePostal: '21800' } } },
         EID = '9582d21d-464b-4654-a556-e9279f425e08';
 
     beforeEach(function() {
         module('ddsApp');
-        inject(function($httpBackend, $location, $browser, ImpactStudyService) {
+        inject(function($httpBackend, $location, $browser, $sessionStorage, ImpactStudyService) {
             subject = ImpactStudyService;
             httpMock = $httpBackend;
             location = $location;
             browserController = $browser;
+            sessionStorage = $sessionStorage;
 
             httpMock.when('POST', /^https\:\/\/mes-droits\.fr\//).respond(200);
             httpMock.when('GET', /^\/.*/).respond(200);
@@ -77,6 +79,40 @@ describe('ImpactStudyService', function() {
             httpMock.expectPOST('https://mes-droits.fr/v1/it');
             subject.sendVisitedPage();
             httpMock.flush();
+        });
+    });
+
+    describe('session id', function() {
+        var sessionId;
+
+        beforeEach(function() {
+            location.search({ eid: EID });
+            browserController.poll();
+
+            httpMock.expectPOST('https://mes-droits.fr/v1/it', function(data) {
+                sessionId = JSON.parse(data).session_id;
+                return sessionId;
+            });
+
+            subject.sendVisitedPage();
+        });
+
+        afterEach(function() {
+            httpMock.flush();
+        });
+
+        it('should be consistent', function() {
+            httpMock.expectPOST('https://mes-droits.fr/v1/it', function(data) {
+                return JSON.parse(data).session_id == sessionId;
+            });
+        });
+
+        it('should change after a call to resetSessionId()', function() {
+            subject.resetSessionId();
+
+            httpMock.expectPOST('https://mes-droits.fr/v1/it', function(data) {
+                return JSON.parse(data).session_id != sessionId;
+            });
         });
     });
 });

--- a/test/spec/services/impactStudyService.js
+++ b/test/spec/services/impactStudyService.js
@@ -1,0 +1,82 @@
+'use strict';
+
+describe('ImpactStudyService', function() {
+    var subject,
+        httpMock,
+        location,
+        browserController;
+
+    var SITUATION = { logement: { adresse: { codePostal: '21800' } } },
+        EID = '9582d21d-464b-4654-a556-e9279f425e08';
+
+    beforeEach(function() {
+        module('ddsApp');
+        inject(function($httpBackend, $location, $browser, ImpactStudyService) {
+            subject = ImpactStudyService;
+            httpMock = $httpBackend;
+            location = $location;
+            browserController = $browser;
+
+            httpMock.when('POST', /^https\:\/\/mes-droits\.fr\//).respond(200);
+            httpMock.when('GET', /^\/.*/).respond(200);
+
+            httpMock.flush();
+        });
+    });
+
+    afterEach(function() {
+        httpMock.verifyNoOutstandingExpectation();
+        httpMock.verifyNoOutstandingRequest();
+    });
+
+    function validate(data) {
+        data = JSON.parse(data);
+        return data.postcode == SITUATION.logement.adresse.codePostal
+            && data.eid == EID;
+    }
+
+    describe('sendResults()', function() {
+        it('should not send anything if no research ID is set', function() {
+            subject.sendResults(SITUATION, {});
+        });
+
+        it('should send data if a research ID is set', function() {
+            location.search({ eid: EID });
+            browserController.poll();
+
+            httpMock.expectPOST('https://mes-droits.fr/sr', validate);
+            subject.sendResults(SITUATION, {});
+            httpMock.flush();
+        });
+    });
+
+    describe('sendPostCode()', function() {
+        it('should not send anything if no research ID is set', function() {
+            subject.sendResults(SITUATION, {});
+        });
+
+        it('should send data if a research ID is set', function() {
+            location.search({ eid: EID });
+            browserController.poll();
+
+            httpMock.expectPOST('https://mes-droits.fr/cp', validate);
+            subject.sendPostCode(SITUATION);
+            httpMock.flush();
+        });
+    });
+
+    describe('sendPostCode()', function() {
+        it('should not send anything if no research ID is set', function() {
+            subject.sendResults(SITUATION, {});
+        });
+
+        it('should send data if a research ID is set', function() {
+            location.search({ eid: EID });
+            browserController.poll();
+
+            httpMock.expectPOST('https://mes-droits.fr/it');
+            subject.sendVisitedPage();
+            httpMock.flush();
+        });
+    });
+});


### PR DESCRIPTION
Ce code envoie des éléments de suivi de parcours pour les participants à l'étude d'impact de Mes Aides sur une cohorte d'inscrits à Pôle Emploi, dès lors qu'un identifiant de suivi `eid` est passé par la querystring.

Avant de déployer :

- [x] Vérifier que des éléments décrivent la recherche et ses parties prenantes de manière claire sur les serveurs de suivi.