### PR TITLE
Refactor age min validation

### DIFF
--- a/app/js/controllers/foyer/individuForm.js
+++ b/app/js/controllers/foyer/individuForm.js
@@ -6,7 +6,6 @@ angular.module('ddsApp').controller('FoyerIndividuFormCtrl', function($scope, in
     $scope.options = {
         captureRelationConjoint: individuRole == 'conjoint',
         checkNationalite: individuRole == 'demandeur',
-        minAge: 0,
         maxAge: 130
     };
 

--- a/app/js/directives/dateNaissanceMaxAge.js
+++ b/app/js/directives/dateNaissanceMaxAge.js
@@ -16,16 +16,12 @@ angular.module('ddsApp').directive('dateNaissanceMaxAge', function() {
     };
 });
 
-angular.module('ddsApp').directive('dateNaissanceMinAge', function() {
+angular.module('ddsApp').directive('beforeToday', function() {
     return {
         require: 'ngModel',
         link: function($scope, elm, attrs, ctrl) {
             ctrl.$parsers.push(function(momentInstance) {
-                var minimum = $scope.$eval(attrs.dateNaissanceMinAge),
-                    actual = moment().diff(momentInstance, 'years');
-
-                ctrl.$setValidity('dateNaissanceMinAge', actual >= minimum);
-
+                ctrl.$setValidity('beforeToday', moment().diff(momentInstance, 'days') >= 0);
                 return momentInstance;
             });
         }

--- a/app/views/partials/foyer/individu-form.html
+++ b/app/views/partials/foyer/individu-form.html
@@ -11,7 +11,7 @@
         ng-model="individu.dateDeNaissance"
         dds-date
         date-autocomplete
-        date-naissance-min-age="0"
+        before-today
         date-naissance-max-age="options.maxAge"
         auto-focus
         placeholder="JJ/MM/AAAA"
@@ -26,8 +26,8 @@
         <li ng-if="form.dateDeNaissance.$error.dateNaissanceMaxAge">
           Les personnes de plus de {{ options.maxAge }} ans ne sont pas prises en compte.
         </li>
-        <li ng-if="form.dateDeNaissance.$error.dateNaissanceMinAge">
-          Cette personne ne peut pas avoir moins de {{ options.minAge }} ans.
+        <li ng-if="form.dateDeNaissance.$error.beforeToday">
+          La date de naissance de cette personne doit être antérieure à aujourd'hui.
         </li>
       </ul>
     </div>

--- a/app/views/partials/foyer/individu-form.html
+++ b/app/views/partials/foyer/individu-form.html
@@ -27,7 +27,8 @@
           Les personnes de plus de {{ options.maxAge }} ans ne sont pas prises en compte.
         </li>
         <li ng-if="form.dateDeNaissance.$error.beforeToday">
-          La date de naissance de cette personne doit être antérieure à aujourd'hui.
+          Cette personne doit être déjà née pour être prise en compte.<br>
+          Pour simuler une naissance future, imaginez qu'elle a eu lieu aujourd'hui et déclarez vos revenus en conséquence.
         </li>
       </ul>
     </div>


### PR DESCRIPTION
With the current behaviour, if the user declares a person born within the next year, the UI won't show any validation error but openfisca will crash at the end of the simulation.

This PR thus tighten the validation.

This bug has been reported by a user (L.R.) on  2016 June 14th, 23:13