### PR TITLE
Fix dependencies in recap embeded component

### DIFF
--- a/app/js/embed.js
+++ b/app/js/embed.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var app = angular.module('ddsRecapSituation', ['ui.router', 'ddsCommon']);
+var app = angular.module('ddsRecapSituation', ['ui.router', 'ddsCommon', 'angular-uuid']);
 
 app.config(function($locationProvider, $stateProvider) {
     moment.lang('fr');

--- a/app/js/services/impactStudyService.js
+++ b/app/js/services/impactStudyService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('ddsApp').service('ImpactStudyService', function($location, $http, $localStorage, $sessionStorage, $log, uuid) {
+angular.module('ddsCommon').service('ImpactStudyService', function($location, $http, $localStorage, $sessionStorage, $log, uuid) {
     var RESEARCH_DOMAIN = 'mes-droits.fr';  // this domain is owned by Poverty Lab researchers mandated by Pole Emploi and DGCS
 
 

--- a/app/views/embed.html
+++ b/app/views/embed.html
@@ -17,6 +17,7 @@
     <!-- bower:js -->
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
+    <script src="bower_components/angular-uuids/angular-uuid.js"></script>
     <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
     <script src="bower_components/moment/moment.js"></script>
     <script src="bower_components/lodash/dist/lodash.compat.js"></script>
@@ -37,6 +38,7 @@
 
     <script src="js/services/individuService.js"></script>
     <script src="js/services/situationService.js"></script>
+    <script src="js/services/impactStudyService.js"></script>
 
     <script src="js/directives/recapSituation.js"></script>
 


### PR DESCRIPTION
Bug introduced by #288 

`SituationService` depends on `ImpactStudyService` since this PR, and the module `ddsRecapSituation` depends on `SituationService`. So we need to pass `ddsRecapSituation` extra dependencies, even though it doesn't need it...