### PR TITLE
Deprecate openfisca ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,20 @@ ssh openfisca-mes-aides@mes-aides.gouv.fr ./deploy
 
 ### Déployer une feature branch
 
-Chaque feature branch est déployée sur le serveur de production par un utilisateur spécifique `mes-aides-$BRANCH`. Lorsque cet utilisateur exécute le script de déploiement `deploy.sh`, les branches `$BRANCH` de mes-aides-ui et [openfisca](https://github.com/sgmap/openfisca) sont déployées. Si cette branche n'existe pas sur le dépôt openfisca, la branche `master` est déployée.
+
+Chaque feature branch est déployée sur le serveur de production par un utilisateur spécifique `mes-aides-$BRANCH`. Lorsque cet utilisateur exécute le script de déploiement `deploy.sh`, la branche `$BRANCH` de mes-aides-ui est déployée.
 
 > La taille du nom d'utilisateur étant limitée à 32 caractères sur le serveur de production, le nom de la feature branch ne doit pas dépasser 22 caractères.
 
+Pour utiliser dans l'instance de staging une feature branch d'`openfisca-france`, éditer le fichier [`openfisca/requirements.txt`](openfisca/requirements.txt), par exemple en remplaçant :
+
+```
+openfisca_france==4.0.5
+```
+par
+```
+git+https://github.com/sgmap/openfisca-france.git@aah#egg=openfisca-france
+```
 
 #### Ajouter un utilisateur capable de déployer sur le serveur de production
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -65,7 +65,7 @@ fi
 
 pip install --requirement mes-aides-ui/openfisca/requirements.txt $user_option
 
-sed s/%PORT%/$OPENFISCA_PORT/ mes-aides-ui/openfisca/api_config.ini > current_openfisca_config.ini
+sed s/"port = 2000"/"port = $OPENFISCA_PORT"/ mes-aides-ui/openfisca/api_config.ini > current_openfisca_config.ini
 
 # Stop OpenFisca
 forever stop openfisca || echo 'No OpenFisca server was running'

--- a/deploy.sh
+++ b/deploy.sh
@@ -34,11 +34,11 @@ echo "OpenFisca expected to run on $OPENFISCA_PORT" >> $LOG_FILE
 echo "Server expected to be visible on $PUBLIC_HOST" >> $LOG_FILE
 
 # Install Mes Aides
-if ! cd mes-aides-ui
-then
+if [ ! -d "mes-aides-ui" ]; then
     git clone https://github.com/sgmap/mes-aides-ui.git --branch $TARGET_BRANCH
-    cd mes-aides-ui
 fi
+
+cd mes-aides-ui
 
 git fetch origin $TARGET_BRANCH
 git checkout origin/$TARGET_BRANCH
@@ -58,26 +58,20 @@ OPENFISCA_URL="http://localhost:$OPENFISCA_PORT" SESSION_SECRET=foobar NODE_ENV=
 cd ..
 
 # Install OpenFisca
-if ! cd openfisca
-then
-    git clone https://github.com/sgmap/openfisca.git
-    cd openfisca
+
+if [[ ! $VIRTUAL_ENV ]]; then
+    user_option='--user'
 fi
 
-if ! ./update.sh $TARGET_BRANCH
-then
-    echo "No branch $TARGET_BRANCH was found on sgmap/openfisca. Staying on current branch."
-    ./update.sh
-fi
+pip install --requirement mes-aides-ui/openfisca/requirements.txt $user_option
 
-PORT=$OPENFISCA_PORT ./generateMesAidesConfig.sh
+sed s/%PORT%/$OPENFISCA_PORT/ mes-aides-ui/openfisca/api_config.ini > current_openfisca_config.ini
 
 # Stop OpenFisca
 forever stop openfisca || echo 'No OpenFisca server was running'
 
 # Start OpenFisca
-forever --uid openfisca -l ../openfisca.log -e ../openfisca_error.log --append start -c "paster serve" config/current.ini
-cd ..
+forever --uid openfisca -l openfisca.log -e openfisca_error.log --append start -c "paster serve" current_openfisca_config.ini
 
 # Set up reverse proxy
 

--- a/openfisca/api_config.ini
+++ b/openfisca/api_config.ini
@@ -1,0 +1,49 @@
+# OpenFisca-Web-API - Development environment configuration
+#
+# The %(here)s variable will be replaced with the parent directory of this file.
+
+[DEFAULT]
+debug = true
+
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = %PORT%
+
+[app:main]
+use = egg:OpenFisca-Web-API
+country_package = openfisca_france
+log_level = DEBUG
+reforms =
+    openfisca_france.reforms.aides_cd93.aides_cd93
+extensions =
+    openfisca_paris
+
+# Logging configuration
+[loggers]
+keys = root, openfisca_web_api
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_openfisca_web_api]
+level = DEBUG
+handlers =
+qualname = openfisca_web_api
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s,%(msecs)03d %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/openfisca/api_config.ini
+++ b/openfisca/api_config.ini
@@ -8,7 +8,7 @@ debug = true
 [server:main]
 use = egg:Paste#http
 host = 0.0.0.0
-port = %PORT%
+port = 2000
 
 [app:main]
 use = egg:OpenFisca-Web-API

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,0 +1,3 @@
+openfisca_web_api[paster]==1.2.0
+openfisca_france==4.0.5
+git+https://github.com/sgmap/openfisca-paris.git@5bd3dc249fdd0b364732edc8d45b79602631b111#egg=openfisca-paris


### PR DESCRIPTION
Goal and approach
-------------------

This PR aims at showing how we could use the benefits of the now strict versioning of openfisca to deprecate the meta-repo github.com/sgmap/openfisca, to open a discussion.

The deployment process we use for feature branch has been therefore rewritten without using this meta-repo.

Feasibility
----------
The dependencies towards `core` and `parsers` are now managed through versioning, so we don't need to worry about them.

The dependency between `france` and `web-api` is weak: `france` just needs to expose its TaxBenefitSystem so that the api can serve it. I don't see much risk of incompatibility.

However, we want to protect ourselves from breaking changes in `france` (e.g. renaming) and in `web-api` (e.g. route changes). **So we would have to store somewhere (openfisca_config.ini ?) the  major versions we want to install for the two packets.** Or the exact version, if we are afraid of the risk of undetected breaking changes.

The extensions are a little more annoying, as we have less control over their repository, and so far they are not released, versioned, or checked with CI. To be safe, we should thus **store the sha1 of the commit** we want to deploy, and run all tests when our partners want to update the code.

Strategy
--------

The fact that we still have to save somewhere 2 version numbers and a sha1 (and more if others extensions are coming) make me question the interest of deprecating the repository. A different strategy could be to simplify the meta repo by just removing references to `core` and `parsers`.

I still think deprecating it would have some advantages, as all what is necessary to run mes-aides would be on only one repository. Also, as the versioning is more clean now, it is less likely that other openfisca users use the meta-repository.

@MattiSG , what are your thoughts ?
