### PR TITLE
Improve integration tests reliability

### DIFF
--- a/app/js/controllers/foyer/logement.js
+++ b/app/js/controllers/foyer/logement.js
@@ -86,6 +86,9 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
     };
 
     $scope.updateCities = function updateCities() {
+        if (! $scope.logement.postalCode)
+            return;  // the user has made the value invalid since we were called
+
         $scope.retrievingCities = true;
 
         $http.get('/api/outils/communes/' + $scope.logement.postalCode)

--- a/app/views/partials/foyer/logement.html
+++ b/app/views/partials/foyer/logement.html
@@ -117,6 +117,7 @@
               minlength="5"
               maxlength="5"
               pattern="[0-9]{5}"
+              ng-pattern="/[0-9]{5}/"
               title="Cinq chiffres"
               class="form-control"
               id="postal-code"

--- a/test/integration/config-ie.json
+++ b/test/integration/config-ie.json
@@ -1,6 +1,6 @@
 {
     "baseURL": "http://localhost:9000",
-    "quit": "on success",
+    "quit": "always",
     "bail": true,
     "timeout": 10000,
     "views": [ "Verbose", "SauceLabs" ],


### PR DESCRIPTION
- Fix #197.
- Avoid wasting 90s in SauceLabs tests.
- ~~Ensure `npm start` defaults to `production` environment to decrease risks of discrepancies (cf. #322).~~ (removed from this PR, was too big)