### PR TITLE
Expose NPM API rather than Grunt tasks

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
-NODE_ENV=development
+NODE_ENV=production
 MONGODB_URL=mongodb://localhost/dds-dev
 SESSION_SECRET=foobar
 OPENFISCA_URL=http://localhost:2000

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
-before_install:
-  - npm install -g grunt-cli
 
 addons:
   ssh_known_hosts: mes-aides.gouv.fr

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,12 +35,6 @@ module.exports = function (grunt) {
           script: 'server.js',
           debug: true
         }
-      },
-      prod: {
-        options: {
-          script: 'server.js',
-          node_env: 'production'
-        }
       }
     },
     open: {
@@ -397,15 +391,7 @@ module.exports = function (grunt) {
     }, 500);
   });
 
-  grunt.registerTask('express-keepalive', 'Keep grunt running', function() {
-    this.async();
-  });
-
   grunt.registerTask('serve', function (target) {
-    if (target === 'dist') {
-      return grunt.task.run(['build', 'express:prod', 'open', 'express-keepalive']);
-    }
-
     if (target === 'debug') {
       return grunt.task.run([
         'clean:server',

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Then, start the server:
 npm start
 ```
 
-or if you want to use grunt (with livereload), you can start it with :
+or if you want to develop interactively, start it with :
 
 ```sh
-grunt serve
+npm run dev
 ```
 
 If you like TDD, you will probably enjoy this command which will run the tests each time a file in the tests/ folder is modified :

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ System dependencies
 
 ### Ubuntu
 
-Make sure `build-essential`, `mongodb`, `node` v0.10, `grunt` and `bower` are installed on your machine
+Make sure `build-essential`, `mongodb`, `node` v0.10 and `bower` are installed on your machine
 
 ```sh
 sudo apt-get install build-essential
@@ -27,7 +27,7 @@ You can for example use [`nvm`](https://github.com/creationix/nvm) to install th
 Once you have Node and npm installed, run:
 
 ```sh
-npm install --global grunt-cli bower
+npm install --global bower
 ```
 
 ### In production
@@ -45,7 +45,6 @@ Application
 git clone https://github.com/sgmap/mes-aides-ui.git
 cd mes-aides-ui
 npm install
-grunt build
 ```
 
 ### Development mode
@@ -77,6 +76,7 @@ grunt serve
 If you like TDD, you will probably enjoy this command which will run the tests each time a file in the tests/ folder is modified :
 
 ```sh
+npm install --global grunt-cli
 grunt watch
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ adduser mes-aides-$BRANCH --disabled-password --gecos ""
 
 # Rendre l'utilisateur accessible depuis l'extérieur
 mkdir /home/mes-aides-$BRANCH/.ssh/
-curl https://github.com/mesaides-bot.keys > /home/mes-aides-$BRANCH/.ssh/authorized_keys
+curl https://github.com/mesaides-bot.keys >> /home/mes-aides-$BRANCH/.ssh/authorized_keys
 
 # Récupérer le script de déploiement
 curl https://raw.githubusercontent.com/sgmap/mes-aides-ui/master/deploy.sh > /home/mes-aides-$BRANCH/deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -63,7 +63,7 @@ if [[ ! $VIRTUAL_ENV ]]; then
     user_option='--user'
 fi
 
-pip install --requirement mes-aides-ui/openfisca/requirements.txt $user_option
+pip install --requirement mes-aides-ui/openfisca/requirements.txt --upgrade $user_option
 
 sed s/"port = 2000"/"port = $OPENFISCA_PORT"/ mes-aides-ui/openfisca/api_config.ini > current_openfisca_config.ini
 

--- a/index.js
+++ b/index.js
@@ -23,9 +23,7 @@ module.exports = function(app) {
         app.use(express.static(path.join(__dirname, 'app')));
 
         viewsDirectory += '/app/views';
-    }
-
-    if ('production' === env) {
+    } else {
         // prerender.io
         app.use(require('prerender-node').set('prerenderToken', process.env.PRERENDER_TOKEN).set('protocol', 'https'));
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "grunt": "~0.4.1",
     "grunt-autoprefixer": "~2.2.0",
     "grunt-bower-install": "~0.7.0",
+    "grunt-cli": "^0.1.13",
     "grunt-concurrent": "~1.0.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-concat": "~0.5.1",
@@ -64,6 +65,8 @@
   },
   "scripts": {
     "postinstall": "bower install",
+    "prestart": "grunt build",
+    "start": "NODE_ENV=production node server.js",
     "test": "grunt",
     "test-integration": "test/integration/run-integration-tests.sh"
   },

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "postinstall": "bower install",
     "prestart": "grunt build",
     "start": "NODE_ENV=production node server.js",
+    "dev": "grunt serve",
     "test": "grunt",
     "test-integration": "test/integration/run-integration-tests.sh"
   },

--- a/server.js
+++ b/server.js
@@ -9,13 +9,11 @@ ludwigConfig.mesAidesRootUrl = process.env.MES_AIDES_ROOT_URL || 'http://localho
 
 // Setup Express
 var app = express();
-var env = app.get('env');
 
-if ('development' === env) {
+if (app.get('env') == 'development') {
     app.use(morgan('dev'));
-}
-
-if ('production' === env) {
+    app.use(errorHandler());
+} else {
     app.use(morgan('combined'));
 }
 

--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var express = require('express');
 var errorHandler = require('errorhandler');
 var morgan = require('morgan');

--- a/server.js
+++ b/server.js
@@ -3,9 +3,9 @@ var errorHandler = require('errorhandler');
 var morgan = require('morgan');
 var ludwigConfig = require('./ludwig/config.json');
 
-process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+var port = process.env.PORT || 9000;
 
-ludwigConfig.mesAidesRootUrl = process.env.MES_AIDES_ROOT_URL || 'http://localhost:9000';
+ludwigConfig.mesAidesRootUrl = process.env.MES_AIDES_ROOT_URL || ('http://localhost:' + port);
 
 // Setup Express
 var app = express();
@@ -20,17 +20,11 @@ if (app.get('env') == 'development') {
 // Setup app
 app.use('/api', require('sgmap-mes-aides-api'));
 app.use(ludwigConfig.baseUrl, require('ludwig-ui')(ludwigConfig));
-require('./')(app);
-
-if ('development' === env) {
-    app.use(errorHandler());
-}
-
-var port = process.env.PORT || 9000;
+require('./index.js')(app);
 
 // Start server
 app.listen(port, function () {
-    console.log('Express server listening on port %d, in %s mode', port, app.get('env'));
+    console.log('Mes Aides server listening on port %d, in %s mode, expecting to be deployed on %s', port, app.get('env'), ludwigConfig.mesAidesRootUrl);
 });
 
-exports = module.exports = app;
+module.exports = app;


### PR DESCRIPTION
Increase readability of environments.
Do not rely on globally installed Grunt.

Partial extract of #330.