### PR TITLE
Fix integration tests (following #361)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "karma-jasmine": "~0.3.5",
     "karma-ng-html2js-preprocessor": "~0.1.0",
     "karma-ng-scenario": "~0.1.0",
-    "karma-phantomjs-launcher": "~0.1.4",
+    "karma-phantomjs-launcher": "~1.0.2",
     "karma-requirejs": "~0.2.1",
     "karma-script-launcher": "~0.1.0",
     "load-grunt-tasks": "~3.1.0",

--- a/test/integration/base-suite/6 - Declare salary scenario.js
+++ b/test/integration/base-suite/6 - Declare salary scenario.js
@@ -1,7 +1,6 @@
 description: 'Declare salary.',
 
 steps: [
-    ResourcesComponent.declareRevenuActivite(),
     ResourcesComponent.hasSalary(),
     ResourcesComponent.submit(),
     ResourcesComponent.setFirstMonthInput(1000),

--- a/test/integration/components/ResourcesComponent.js
+++ b/test/integration/components/ResourcesComponent.js
@@ -1,4 +1,3 @@
-declareRevenuActiviteLink: { a: 'Revenus d' },
 declareFirstChildHasIncomeRadio: 'yes-no-question [ng-class*="true"]',
 hasSalaryCheckbox: 'uib-accordion label',
 firstMonthInput: '#revenusSalarie-month_1',

--- a/test/integration/family-suite/65 - Declare family resources scenario.js
+++ b/test/integration/family-suite/65 - Declare family resources scenario.js
@@ -4,7 +4,6 @@ steps: [
     ResourcesComponent.submit(), // No resource for the conjoint
     ResourcesComponent.declareFirstChildHasIncome(),
     ResourcesComponent.submit(),
-    ResourcesComponent.declareRevenuActivite(),
     ResourcesComponent.hasSalary(),
     ResourcesComponent.submit(),
     ResourcesComponent.setThirdMonthInput(400),

--- a/test/integration/ludwig-suite/LudwigComponent.js
+++ b/test/integration/ludwig-suite/LudwigComponent.js
@@ -1,2 +1,2 @@
 testsCount: 'h2',
-toggleFirstTestLink: '.panel h4',
+toggleFirstTestLink: '.panel-title a',


### PR DESCRIPTION
L'onglet "Revenus d'activité" étant ouvert par défaut depuis #361, il ne faut pas cliquer sur l'onglet avant de déclarer un salaire, sinon on le ferme.