### PR TITLE
Redéployer openfisca dans le script de déploiement continu

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,8 @@ Une clé SSH autorisée à se connecter au serveur de production `mes-aides.gouv
 ssh deploy@mes-aides.gouv.fr
 ```
 
-L'utilisateur `deploy` est utilisé comme un endpoint pour lancer le script de déploiement `~/deploy.sh`. Aucune autre action n'est possible avec cet utilisateur. Pour modifier la procédure de déploiement, se connecter en tant que `root`.
+L'utilisateur `deploy` est utilisé comme un endpoint pour lancer le script de déploiement `deploy-prod.sh` (via un lien symbolique). Ce script déploie à la fois l'application et Openfisca. Aucune autre action n'est possible avec cet utilisateur. Pour modifier la procédure de déploiement, se connecter en tant que `root`.
 
-### OpenFisca
-
-```sh
-ssh openfisca-mes-aides@mes-aides.gouv.fr ./deploy
-```
 
 ### Déployer une feature branch
 

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -2,6 +2,8 @@
 # This script is not currently meant to be executed from within the repository.
 # Copy or symlink it to some deployment directory.
 
+OPENFISCA_PORT=12000
+
 set -ex
 
 cd /var/www/dds
@@ -15,7 +17,7 @@ grunt build
 
 # Update openfisca
 npm run install-openfisca
-cat openfisca/api_config.ini | sed s/"port = 2000"/"port = 12000"/ > ~/production.ini
+cat openfisca/api_config.ini | sed "s/port = 2000/port = $OPENFISCA_PORT"/ > ~/production.ini
 
 # Restart mes-aides
 sudo restart dds

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# This script is not currently meant to be executed from within the repository.
+# Copy or symlink it to some deployment directory.
+
+set -ex
+
+cd /var/www/dds
+
+# Update mes-aides
+git fetch origin
+git rebase origin/master
+npm install
+grunt build
+
+# Update openfisca
+npm run install-openfisca
+cat openfisca/api_config.ini | sed s/"port = 2000"/"port = 12000"/ > ~/production.ini
+
+# Restart mes-aides
+sudo restart dds
+
+# Restart openfisca
+sudo start openfisca || sudo restart openfisca
+
+echo "Déploiement effectué"

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -20,7 +20,7 @@ npm run install-openfisca
 cat openfisca/api_config.ini | sed "s/port = 2000/port = $OPENFISCA_PORT"/ > ~/production.ini
 
 # Restart mes-aides
-sudo restart dds
+sudo start dds || sudo restart dds
 
 # Restart openfisca
 sudo start openfisca || sudo restart openfisca

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -8,7 +8,8 @@ cd /var/www/dds
 
 # Update mes-aides
 git fetch origin
-git rebase origin/master
+git checkout --force --detach origin/master
+git clean --force
 npm install
 grunt build
 

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -13,7 +13,7 @@ git fetch origin
 git checkout --force --detach origin/master
 git clean --force
 npm install
-grunt build
+npm run prestart
 
 # Update openfisca
 npm run install-openfisca


### PR DESCRIPTION
Cette PR permet de
- Ajouter le script de déploiement utilisé en production dans le repo pour qu'il soit versionné.
    - Avant, on n'avait aucune sauvegarde des changements.
- Redéployer openfisca dans le script de déploiement continu, pour garantir qu'il n'y ait pas d'incohérence entre mes-aides et openfisca.
    - Avant, il fallait se connecter avec un user spécifique `openfisca-mes-aides` pour déployer openfisca, avec un risque d'oubli.

Bien sûr, ce qu'il faudrait faire c'est merger complètement les processus de déploiement de la prod et des instances de staging (qui gèrent déjà à la fois openfisca et le front). Mais il reste quelques obstacles, notamment le fait utiliser node 0.10, qui est incompatible avec pm2.