### PR TITLE
Simplifier l'interface de capture des revenus TNS

### DIFF
--- a/app/js/controllers/foyer/ressources/individu.js
+++ b/app/js/controllers/foyer/ressources/individu.js
@@ -52,17 +52,6 @@ angular.module('ddsApp').controller('FoyerRessourcesIndividuCtrl', function($sco
                 onGoing: true
             };
 
-            // For autres revenus TNS, we also need to find the CA
-            if (type == 'autresRevenusTns') {
-                ressource.caAnnuel = _.chain(ressources)
-                    .where({ type: 'caAutresRevenusTns' })
-                    .pluck('montant')
-                    .reduce(function(sum, montant) {
-                        return sum + montant;
-                    })
-                    .value();
-            }
-
             if (_.contains(individu.interruptedRessources, type)) {
                 ressource.onGoing = false;
             }

--- a/app/js/services/ressourceService.js
+++ b/app/js/services/ressourceService.js
@@ -38,24 +38,15 @@ angular.module('ddsApp').factory('RessourceService', function(SituationService, 
     }
 
     function applyYearlyRessource (individu, ressource, dateDeValeur) {
-            var montant = ressource.montantAnnuel;
-            var periode = moment(dateDeValeur).subtract(1, 'year').format('YYYY');
-            if (montant) {
-                individu.ressources.push({
-                    type: ressource.type.id,
-                    periode: periode,
-                    montant: montant
-                });
-            }
-
-            // For  'professions libérales et entrepreneurs', we capture the 'CA' as well as the 'benefice'
-            if (ressource.type.id == 'autresRevenusTns' && ressource.caAnnuel) {
-                individu.ressources.push({
-                    type: 'caAutresRevenusTns',
-                    periode: periode,
-                    montant: ressource.caAnnuel
-                });
-            }
+        var montant = ressource.montantAnnuel;
+        var periode = moment(dateDeValeur).subtract(1, 'year').format('YYYY');
+        if (montant) {
+            individu.ressources.push({
+                type: ressource.type.id,
+                periode: periode,
+                montant: montant
+            });
+        }
     }
 
     function applyRessourcesToIndividu (individu, ressources, dateDeValeur) {
@@ -83,7 +74,7 @@ angular.module('ddsApp').factory('RessourceService', function(SituationService, 
     function isRessourceOnMainScreen(ressourceOrType) {
         // Make this function robust so that it can be called with a ressource from individu.ressources, a type from the ressourceTypes constant, or just a string.
         var type = ressourceOrType.type || ressourceOrType.id || ressourceOrType;
-        return type != 'pensionsAlimentairesVersees' && type != 'caAutresRevenusTns' && ! _.find(categoriesRnc, { id: type });
+        return type != 'pensionsAlimentairesVersees' && ! _.find(categoriesRnc, { id: type });
     }
 
     function getMainScreenRessources(individu) {

--- a/app/views/partials/foyer/ressources/detail-montants.html
+++ b/app/views/partials/foyer/ressources/detail-montants.html
@@ -134,30 +134,7 @@
             <option value="bnc">Activité libérale et/ou intellectuelle (BNC)</option>
           </select>
         </div>
-
-        <div class="col-sm-3">
-          <label for="ca-individu-{{ individuIndex }}">
-            <abbr title="Chiffre d'affaires">CA</abbr> sur le dernier exercice clos
-          </label>
-          <span class="input-group">
-            <input
-              type="number"
-              id="ca-individu-{{ individuIndex }}"
-              class="form-control text-right"
-              required
-              min="0"
-              step="1000"
-              select-on-focus
-              zero-to-empty
-              ng-model="ressource.caAnnuel">
-            <span class="input-group-addon">€</span>
-          </span>
-          <span class="text-danger" ng-if="form.submitted && ! isNumber(ressource.caAnnuel)">
-            Montant invalide
-          </span>
-        </div>
-
-        <div class="col-sm-4">
+        <div class="col-sm-7">
           <label
             for="revenus-exercice-individu-{{ individuIndex }}">
           Bénéfice sur le dernier exercice clos
@@ -179,14 +156,6 @@
           Montant invalide
           </span>
         </div>
-      </div>
-      <div class="checkbox">
-        <label>
-        <input
-          type="checkbox"
-          ng-model="individu.autresRevenusTnsEmployes">
-        J'ai au moins un employé
-        </label>
       </div>
     </div>
   </div>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "morgan": "~1.5.0",
     "prerender-node": "^1.1.1",
     "serve-favicon": "~2.2.0",
-    "sgmap-mes-aides-api": "sgmap/mes-aides-api#v6.2.1"
+    "sgmap-mes-aides-api": "sgmap/mes-aides-api#v7.0.0"
   },
   "repository": {
     "type": "git",

--- a/test/spec/services/ressourceService.js
+++ b/test/spec/services/ressourceService.js
@@ -30,21 +30,6 @@ describe('ResultatService', function () {
             expect(individu.ressources).not.toEqual([]);
             expect(individu.ressources[0].type).toEqual('revenusAgricolesTns');
         });
-
-        it('should add caAutresRevenusTns to individu model when autresRevenusTns are declared', function() {
-            ressource = {
-                type: {
-                    id: 'autresRevenusTns'
-                },
-                montantAnnuel: 12000,
-                caAnnuel: 20000,
-                periode: 2014
-            };
-            service.applyYearlyRessource(individu, ressource, dateDeValeur);
-            expect(individu.ressources).not.toEqual([]);
-            expect(individu.ressources[0].type).toEqual('autresRevenusTns');
-            expect(individu.ressources[1].type).toEqual('caAutresRevenusTns');
-        });
     });
     describe('isRessourceOnMainScreen', function() {
         it('should filter pensions alimentaires versées and RNC resources', function() {


### PR DESCRIPTION
Depends on sgmap/mes-aides-api#104

Vu qu'il n'y a plus de conditions spécifiques sur le CA des TNS et le fait d'avoir ou non un employé, il n'est plus nécessaire de capturer ces champs.