### PR TITLE
Ajouter une condition textuelle pour le RSA

### DIFF
--- a/app/js/constants/droits.js
+++ b/app/js/constants/droits.js
@@ -95,7 +95,7 @@ angular.module('ddsCommon').constant('droitsDescription', {
                     'shortLabel': 'RSA',
                     'description': 'Le RSA est destiné à assurer aux personnes disposant de faibles ressources un niveau minimum de revenu variable selon la composition de leur foyer.',
                     'conditions': [
-                        'Signer un engagement avec votre département.',
+                        'Signer un <a href="http://social-sante.gouv.fr/affaires-sociales/lutte-contre-l-exclusion/droits-et-aides/le-revenu-de-solidarite-active-rsa/article/quels-sont-les-droits-et-devoirs-des-beneficiaires-du-rsa" title="Détails sur les droits et devoirs des bénéficiaires du RSA">contrat d’engagement réciproque</a> avec votre département.',
                         'Résider en France plus de 9 mois par an.',
                         'Si vous êtes ressortissant·e d’un pays de l’UE, de l’EEE ou Suisse, résider en France depuis plus de 3 mois.',
                         'Si vous êtes ressortissant·e d’un autre pays, résider en France depuis plus de 5 ans.'

--- a/app/js/constants/droits.js
+++ b/app/js/constants/droits.js
@@ -95,6 +95,7 @@ angular.module('ddsCommon').constant('droitsDescription', {
                     'shortLabel': 'RSA',
                     'description': 'Le RSA est destiné à assurer aux personnes disposant de faibles ressources un niveau minimum de revenu variable selon la composition de leur foyer.',
                     'conditions': [
+                        'Signer un engagement avec votre département.',
                         'Résider en France plus de 9 mois par an.',
                         'Si vous êtes ressortissant·e d’un pays de l’UE, de l’EEE ou Suisse, résider en France depuis plus de 3 mois.',
                         'Si vous êtes ressortissant·e d’un autre pays, résider en France depuis plus de 5 ans.'

--- a/app/js/constants/droits.js
+++ b/app/js/constants/droits.js
@@ -95,7 +95,7 @@ angular.module('ddsCommon').constant('droitsDescription', {
                     'shortLabel': 'RSA',
                     'description': 'Le RSA est destiné à assurer aux personnes disposant de faibles ressources un niveau minimum de revenu variable selon la composition de leur foyer.',
                     'conditions': [
-                        'Signer un <a href="http://social-sante.gouv.fr/affaires-sociales/lutte-contre-l-exclusion/droits-et-aides/le-revenu-de-solidarite-active-rsa/article/quels-sont-les-droits-et-devoirs-des-beneficiaires-du-rsa" title="Détails sur les droits et devoirs des bénéficiaires du RSA">contrat d’engagement réciproque</a> avec votre département.',
+                        'Signer un <a target="_blank" href="http://social-sante.gouv.fr/affaires-sociales/lutte-contre-l-exclusion/droits-et-aides/le-revenu-de-solidarite-active-rsa/article/quels-sont-les-droits-et-devoirs-des-beneficiaires-du-rsa" title="Détails sur les droits et devoirs des bénéficiaires du RSA">contrat d’engagement réciproque</a> avec votre département.',
                         'Résider en France plus de 9 mois par an.',
                         'Si vous êtes ressortissant·e d’un pays de l’UE, de l’EEE ou Suisse, résider en France depuis plus de 3 mois.',
                         'Si vous êtes ressortissant·e d’un autre pays, résider en France depuis plus de 5 ans.'


### PR DESCRIPTION
La plupart des conditions semble faire référence au ```vous``` et utilise ```votre/vos```, du coup j'ai utilisé *votre département* plutôt que *le département*.

J'ai ajouté cette contrainte au début de liste car elle me parait être la plus globale.

Should fix #387.