### PR TITLE
Ne pas attribuer du RSA aux étudiants

### DIFF
--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,3 +1,4 @@
 openfisca_web_api[paster]==3.0.0
-openfisca_france==10.0.0b0
+openfisca_france==10.0.0
+openfisca_core==4.4.0.dev0
 git+https://github.com/sgmap/openfisca-paris.git@a4b6f324f48e465b89ffd01d25cea8ff68202718#egg=openfisca-paris


### PR DESCRIPTION
Fix #452 

Je suis pleinement conscient qu'utiliser une version de dev est de la dette, mais c'est le seul moyen que j'ai de résoudre ce bug important avant demain.

Nous verrons fin février les arbitrages qui pourront être trouvés avec toute la communauté openfisca, et rembourserons la dette à ce moment là.