### PR TITLE
Cesse d'animer tous les changements de propriétés CSS

### DIFF
--- a/app/styles/header.css
+++ b/app/styles/header.css
@@ -49,10 +49,6 @@ header[role="banner"] .loading-spinner .loading-spinner-icon {
 	100%	{ transform: rotate(360deg); }
 }
 
-.main-navbar, .body-front {
-	transition: all 0.5s linear;
-}
-
 .body-front {
 	padding-top: 45px;  /* .navbar's min-height */
 }


### PR DESCRIPTION
Ces instructions sont coûteuses en termes de performance pour un gain d'usabilité inconnu. Le seul cas où elles semblent se manifester est au changement de taille de police, une modification qui n'a probablement pas besoin d'être animée.

@Flightan sais-tu pourquoi ces instructions sont là ?