### PR TITLE
Corrige l'exécution de `run openfisca` en local

### DIFF
--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -17,7 +17,7 @@ npm run prestart
 
 # Update openfisca
 npm run install-openfisca
-cat openfisca/api_config.ini | sed "s/port = 2000/port = $OPENFISCA_PORT/" | sed "s/# PROD_ONLY //g" > ~/production.ini
+cat openfisca/api_config.ini | sed "s/port = 2000/port = $OPENFISCA_PORT/" | sed "s/^# PROD_ONLY //g" > ~/production.ini
 
 # Restart mes-aides
 sudo start dds || sudo restart dds

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -17,7 +17,7 @@ npm run prestart
 
 # Update openfisca
 npm run install-openfisca
-cat openfisca/api_config.ini | sed "s/port = 2000/port = $OPENFISCA_PORT"/ > ~/production.ini
+cat openfisca/api_config.ini | sed "s/port = 2000/port = $OPENFISCA_PORT/" | sed "s/# PROD_ONLY //g" > ~/production.ini
 
 # Restart mes-aides
 sudo start dds || sudo restart dds

--- a/openfisca/api_config.ini
+++ b/openfisca/api_config.ini
@@ -5,7 +5,7 @@ debug = true
 use = egg:Paste#http
 host = 0.0.0.0
 port = 2000
-workers = 4
+# PROD_ONLY workers = 4  # not compatible with paster; lines prefixed with this marker will be uncommented automatically on production deployment, which uses gunicorn
 
 [app:main]
 use = egg:OpenFisca-Web-API


### PR DESCRIPTION
#493 a augmenté les performances de la production qui utilise `gunicorn`, mais a rendu le fichier de configuration incompatible avec `paster`, le serveur par défaut utilisé en environnement de développement.

Ce jeu de changements ajoute un préfixe `# PROD_ONLY ` à utiliser dans le fichier de configuration, qui sera supprimé en mode production.

Ce correctif n'est pas une solution propre, et devrait être remplacé à terme par une uniformisation des environnements de développement et de production.