### PR TITLE
Retire le prérendu statique obsolète

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,5 +2,4 @@ NODE_ENV=production
 MONGODB_URL=mongodb://localhost/dds-dev
 SESSION_SECRET=foobar
 OPENFISCA_URL=http://localhost:2000
-PRERENDER_TOKEN=foobar
 MES_AIDES_ROOT_URL=http://localhost:5000

--- a/index.js
+++ b/index.js
@@ -24,9 +24,6 @@ module.exports = function(app) {
 
         viewsDirectory += '/app/views';
     } else {
-        // prerender.io
-        app.use(require('prerender-node').set('prerenderToken', process.env.PRERENDER_TOKEN).set('protocol', 'https'));
-
         app.use('/recap-situation', express.static(path.join(__dirname, 'dist')));
 
         viewsDirectory += '/dist/views';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "font-awesome": "^4.7.0",
     "ludwig-ui": "^1.5.0",
     "morgan": "~1.5.0",
-    "prerender-node": "^1.1.1",
     "serve-favicon": "^2.4.0",
     "sgmap-mes-aides-api": "sgmap/mes-aides-api#v7.2.0"
   },


### PR DESCRIPTION
The AJAX crawling scheme has been [deprecated](https://webmasters.googleblog.com/2015/10/deprecating-our-ajax-crawling-scheme.html) by Google in 2015.
The old free prerender.io token is not enough to support the current deployment frequency.
Weird prerendering caching has been observed on the server, could be linked to this.