### PR TITLE
Évite le leak d'une variable

### DIFF
--- a/app/js/constants/ressources.js
+++ b/app/js/constants/ressources.js
@@ -31,8 +31,6 @@ angular.module('ddsCommon').constant('ressourceCategories', [
     }
 ]);
 
-var ijssInteruptionQuestionLabel = 'des indemnités de la sécurité sociale, un salaire ou des allocations chômage';
-
 angular.module('ddsCommon').constant('ressourceTypes', [
     {
         id: 'revenusSalarie',
@@ -185,25 +183,25 @@ angular.module('ddsCommon').constant('ressourceTypes', [
         id: 'indJourMaternite',
         label: 'Indemnités de maternité, paternité, adoption',
         category: 'indemnites',
-        interuptionQuestionLabel: ijssInteruptionQuestionLabel
+        interuptionQuestionLabel: 'des indemnités de la sécurité sociale, un salaire ou des allocations chômage'
     },
     {
         id: 'indJourMaladie',
         label: 'Indemnités maladie',
         category: 'indemnites',
-        interuptionQuestionLabel: ijssInteruptionQuestionLabel
+        interuptionQuestionLabel: 'des indemnités de la sécurité sociale, un salaire ou des allocations chômage'
     },
     {
         id: 'indJourMaladieProf',
         label: 'Indemnités maladie professionnelle',
         category: 'indemnites',
-        interuptionQuestionLabel: ijssInteruptionQuestionLabel
+        interuptionQuestionLabel: 'des indemnités de la sécurité sociale, un salaire ou des allocations chômage'
     },
     {
         id: 'indJourAccidentDuTravail',
         label: 'Indemnités d’accident du travail',
         category: 'indemnites',
-        interuptionQuestionLabel: ijssInteruptionQuestionLabel
+        interuptionQuestionLabel: 'des indemnités de la sécurité sociale, un salaire ou des allocations chômage'
     },
     {
         id: 'indChomagePartiel',


### PR DESCRIPTION
La variable `ijssInteruptionQuestionLabel` pollue le scope global.

Plutôt que de mettre une [IIFE](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression) pour créer un scope, j'ai considéré qu'il n'y avait pas vraiment de sens à partager un descriptif, et qu'il était plus pertinent de le dupliquer, ce qui en augmentait aussi la malléabilité.