### PR TITLE
Upgrade openfisca

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -71,8 +71,7 @@ sed s/"port = 2000"/"port = $OPENFISCA_PORT"/ mes-aides-ui/openfisca/api_config.
 forever stop openfisca || echo 'No OpenFisca server was running'
 
 # Start OpenFisca
-forever --uid openfisca -l openfisca.log -e openfisca_error.log --append start -c "paster serve" current_openfisca_config.ini
-
+forever --uid openfisca -l openfisca.log -e openfisca_error.log --append start -c "gunicorn --paster" current_openfisca_config.ini
 # Set up reverse proxy
 
 echo "upstream $USER {

--- a/openfisca/api_config.ini
+++ b/openfisca/api_config.ini
@@ -11,11 +11,10 @@ workers = 4
 use = egg:OpenFisca-Web-API
 country_package = openfisca_france
 log_level = DEBUG
-reforms =
-    openfisca_france.reforms.aides_cd93.aides_cd93
 extensions =
     openfisca_paris
     openfisca_rennesmetropole
+    openfisca_cd93
 
 # Logging configuration
 [loggers]

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,6 +1,7 @@
+
 gunicorn>=19.1.1
-openfisca_web_api[paster]==3.3.1
-openfisca_france==15.1.0
+openfisca_web_api==3.4.0
+openfisca_france==16.1.0
 git+https://github.com/sgmap/openfisca-paris.git@06fce8d1fba0cb6523bec8988f42135095802540#egg=openfisca-paris
 git+https://github.com/sgmap/openfisca-cd93.git@602b68864706c17591abccd0d5c608e5939e9f03#egg=openfisca-cd93
 git+https://github.com/sgmap/openfisca-rennesmetropole.git@1cc80a370720321b15c409a0783b667689a2eafd#egg=openfisca-RennesMetropole

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,5 +1,6 @@
 gunicorn>=19.1.1
-openfisca_web_api[paster]==3.2.1
-openfisca_france==14.0.0
-git+https://github.com/sgmap/openfisca-paris.git@a4b6f324f48e465b89ffd01d25cea8ff68202718#egg=openfisca-paris
-git+https://github.com/sgmap/openfisca-rennesmetropole.git@3487bb332f4373c3123ebdd7e31ecd4da5d82548#egg=openfisca-RennesMetropole
+openfisca_web_api[paster]==3.3.1
+openfisca_france==15.1.0
+git+https://github.com/sgmap/openfisca-paris.git@06fce8d1fba0cb6523bec8988f42135095802540#egg=openfisca-paris
+git+https://github.com/sgmap/openfisca-cd93.git@602b68864706c17591abccd0d5c608e5939e9f03#egg=openfisca-cd93
+git+https://github.com/sgmap/openfisca-rennesmetropole.git@1cc80a370720321b15c409a0783b667689a2eafd#egg=openfisca-RennesMetropole

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -4,4 +4,4 @@ openfisca_web_api==3.4.0
 openfisca_france==16.1.0
 git+https://github.com/sgmap/openfisca-paris.git@06fce8d1fba0cb6523bec8988f42135095802540#egg=openfisca-paris
 git+https://github.com/sgmap/openfisca-cd93.git@602b68864706c17591abccd0d5c608e5939e9f03#egg=openfisca-cd93
-git+https://github.com/sgmap/openfisca-rennesmetropole.git@1cc80a370720321b15c409a0783b667689a2eafd#egg=openfisca-RennesMetropole
+git+https://github.com/sgmap/openfisca-rennesmetropole.git@0870aa5298940a7dbcb11ddb186560d057b92402#egg=openfisca-RennesMetropole

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,5 +1,5 @@
 gunicorn>=19.1.1
-openfisca_web_api==3.0.0
-openfisca_france==10.2.0
+openfisca_web_api[paster]==3.2.1
+openfisca_france==14.0.0
 git+https://github.com/sgmap/openfisca-paris.git@a4b6f324f48e465b89ffd01d25cea8ff68202718#egg=openfisca-paris
 git+https://github.com/sgmap/openfisca-rennesmetropole.git@3487bb332f4373c3123ebdd7e31ecd4da5d82548#egg=openfisca-RennesMetropole

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ludwig-ui": "^1.5.0",
     "morgan": "~1.5.0",
     "serve-favicon": "^2.4.0",
-    "sgmap-mes-aides-api": "sgmap/mes-aides-api#v7.2.0"
+    "sgmap-mes-aides-api": "sgmap/mes-aides-api#v7.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Certains tests changent de couleur avec cette PR. Un certains nombre passent du rouge à l'orange ou de l'orange au vert, mais certains passent aussi du vert à l'orange.

Pour la grande majorité de ces-derniers, il s'agit de tests qui n'ont pas été créés à partir de cas réels, mais de notre interprétation de la loi... qui ne tenait pas compte d'une réforme de début 2015. Ces tests seront donc à changer dans la base de données de test, et leur passage à l'orange n'est pas un problème.

3-4 autres tests censés être plus fiables passent également à l'orange, avec un résultat sur les aides au logement qui varie de quelques euros. Vu l'amplitude, ça ne me paraît pas être bloquant. Il faut de toute façon profiter des derniers tests ajoutés par la DHUP pour gagner en fiabilité sur les AL. 