### PR TITLE
Fixe le bug "Internal server error" et n'affiche pas la Prime d'activité déclarée comme un résultat

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ludwig-ui": "^1.5.0",
     "morgan": "~1.5.0",
     "serve-favicon": "^2.4.0",
-    "sgmap-mes-aides-api": "sgmap/mes-aides-api#v7.3.0"
+    "sgmap-mes-aides-api": "sgmap/mes-aides-api#v7.3.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes https://github.com/sgmap/mes-aides-api/issues/115
Fix le bug rencontré en production le 12/04/2017 (internal server error)