### PR TITLE
Stop relying on deprecated method to send HTML status back

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function(app) {
     app.use('/partials', express.static(viewsDirectory + '/partials'));
     app.use('/content-pages', express.static(viewsDirectory + '/content-pages'));
     app.use('/partials', function(req, res) {
-        return res.send(404);
+        return res.sendStatus(404);
     });
 
     app.use('/js/lib', express.static(path.join(__dirname, 'node_modules'), {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "mongoose": "^4.5.1",
     "morgan": "~1.8.0",
     "serve-favicon": "^2.4.0",
-    "sgmap-mes-aides-api": "sgmap/mes-aides-api#v9.0.0"
+    "sgmap-mes-aides-api": "sgmap/mes-aides-api#v9.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove this warning from server logs:
```bash
express deprecated res.send(status): Use res.sendStatus(status) instead index.js:50:20
```


Should add API upgrade in this PR (https://github.com/sgmap/mes-aides-api/pull/125).

- [ ] Update API version

