### PR TITLE
Clarify last-12-month input label

### DIFF
--- a/app/js/controllers/foyer/logement.js
+++ b/app/js/controllers/foyer/logement.js
@@ -42,7 +42,7 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
     }
 
     $scope.yearsAgo = function yearsAgo(amount) {
-        return moment().subtract(amount, 'years').format('MMMM YYYY');
+        return moment().subtract(amount, 'years').format('MMMM YYYY');
     };
 
     $scope.captureCharges = function() {

--- a/app/js/controllers/foyer/pensionsAlimentaires.js
+++ b/app/js/controllers/foyer/pensionsAlimentaires.js
@@ -3,8 +3,8 @@
 angular.module('ddsApp').controller('FoyerPensionsAlimentairesCtrl', function($scope, ressourceTypes, SituationService, IndividuService, RessourceService) {
 
     var momentDebutAnnee = moment($scope.situation.dateDeValeur).subtract('years', 1);
-    $scope.debutAnneeGlissante = momentDebutAnnee.format('MMMM YYYY');
-    $scope.currentMonth = moment($scope.situation.dateDeValeur).format('MMMM YYYY');
+    $scope.debutAnneeGlissante = momentDebutAnnee.format('MMMM YYYY');
+    $scope.currentMonth = moment($scope.situation.dateDeValeur).format('MMMM YYYY');
     var months = SituationService.getMonths($scope.situation.dateDeValeur);
 
     var initMontantsMensuels = function(individu, pensionType) {

--- a/app/js/controllers/foyer/ressources/enfants.js
+++ b/app/js/controllers/foyer/ressources/enfants.js
@@ -2,7 +2,7 @@
 
 angular.module('ddsApp').controller('FoyerRessourcesEnfantsCtrl', function($scope, SituationService, RessourceService) {
     var momentDebutAnnee = moment($scope.situation.dateDeValeur).subtract('years', 1);
-    $scope.debutAnneeGlissante = momentDebutAnnee.format('MMMM YYYY');
+    $scope.debutAnneeGlissante = momentDebutAnnee.format('MMMM YYYY');
 
     $scope.enfants = SituationService.getEnfants($scope.situation);
     $scope.enfants.forEach(function(enfant) {

--- a/app/js/controllers/foyer/ressources/montants.js
+++ b/app/js/controllers/foyer/ressources/montants.js
@@ -3,7 +3,7 @@
 angular.module('ddsApp').controller('FoyerRessourcesMontantsCtrl', function($scope, $stateParams, ressourceTypes, RessourceService, IndividuService) {
 
     $scope.yearMoinsUn = moment($scope.situation.dateDeValeur).subtract('years', 1).format('YYYY');
-    $scope.currentMonth = moment($scope.situation.dateDeValeur).format('MMMM YYYY');
+    $scope.currentMonth = moment($scope.situation.dateDeValeur).format('MMMM YYYY');
     $scope.individuLabel = IndividuService.label($scope.individu);
 
     $scope.ressourceTypes = _.keyBy(ressourceTypes, 'id');

--- a/app/js/controllers/foyer/ressources/types.js
+++ b/app/js/controllers/foyer/ressources/types.js
@@ -3,7 +3,7 @@
 angular.module('ddsApp').controller('FoyerRessourceTypesCtrl', function($scope, $stateParams, ressourceCategories, ressourceTypes, $state, RessourceService) {
 
     var momentDebutAnnee = moment($scope.situation.dateDeValeur).subtract('years', 1);
-    $scope.debutAnneeGlissante = momentDebutAnnee.format('MMMM YYYY');
+    $scope.debutAnneeGlissante = momentDebutAnnee.format('MMMM YYYY');
 
     $scope.ressourceCategories = ressourceCategories;
 

--- a/app/js/controllers/foyer/yearMoins2.js
+++ b/app/js/controllers/foyer/yearMoins2.js
@@ -3,7 +3,7 @@
 angular.module('ddsApp').controller('FoyerRessourceYearMoins2Ctrl', function($scope, $state, categoriesRnc, IndividuService, SituationService) {
     var today = $scope.situation.dateDeValeur;
     $scope.yearMoins2 = moment(today).subtract('years', 2).format('YYYY');
-    $scope.debutAnneeGlissante = moment(today).subtract('years', 1).format('MMMM YYYY');
+    $scope.debutAnneeGlissante = moment(today).subtract('years', 1).format('MMMM YYYY');
 
     $scope.individuRefsToDisplay = [];
     $scope.individuRefsToHide = [];

--- a/app/js/controllers/resultat.js
+++ b/app/js/controllers/resultat.js
@@ -36,8 +36,8 @@ angular.module('ddsApp').controller('ResultatCtrl', function($scope, $rootScope,
     });
 
     $scope.yearMoins2 = moment($scope.situation.dateDeValeur).subtract('years', 2).format('YYYY');
-    $scope.debutPeriode = moment($scope.situation.dateDeValeur).startOf('month').subtract('years', 1).format('MMMM YYYY');
-    $scope.finPeriode = moment($scope.situation.dateDeValeur).startOf('month').subtract('months', 1).format('MMMM YYYY');
+    $scope.debutPeriode = moment($scope.situation.dateDeValeur).startOf('month').subtract('years', 1).format('MMMM YYYY');
+    $scope.finPeriode = moment($scope.situation.dateDeValeur).startOf('month').subtract('months', 1).format('MMMM YYYY');
     $scope.ressourcesYearMoins2Captured = SituationService.ressourcesYearMoins2Captured($scope.situation);
 
     $scope.getPartenaireLocalLabel = function(partenaireId) {

--- a/app/js/directives/captureMontantRessource.js
+++ b/app/js/directives/captureMontantRessource.js
@@ -28,9 +28,9 @@ angular.module('ddsApp').directive('captureMontantRessource', function(Situation
         },
         link: function(scope, element, attrs, ngModel) {
             var momentDebutAnnee = moment(scope.dateDeValeur).subtract('years', 1);
-            scope.debutAnneeGlissante = momentDebutAnnee.format('MMMM YYYY');
+            scope.debutAnneeGlissante = momentDebutAnnee.format('MMMM YYYY');
             scope.months = SituationService.getMonths(scope.dateDeValeur);
-            scope.currentMonth = moment(scope.dateDeValeur).format('MMMM YYYY');
+            scope.currentMonth = moment(scope.dateDeValeur).format('MMMM YYYY');
             scope.isNumber = angular.isNumber;
             scope.onGoingLabel = getOnGoingQuestion(scope.individu, scope.ressourceType, scope.currentMonth);
 

--- a/app/js/directives/recapSituation.js
+++ b/app/js/directives/recapSituation.js
@@ -39,7 +39,7 @@ angular.module('ddsRecapSituation').directive('recapSituation', function($timeou
                         var ressource = subRessources[i];
                         if (ressource) {
                             values.values.push({
-                                periode: moment(ressource.periode, 'YYYY-MM').format('MMMM YYYY'),
+                                periode: moment(ressource.periode, 'YYYY-MM').format('MMMM YYYY'),
                                 montant: ressource.montant
                             });
                         }
@@ -140,7 +140,7 @@ angular.module('ddsRecapSituation').directive('recapSituation', function($timeou
                         for (var i = 0; i < 3; i++) {
                             var ressource = revenus[i];
                             value.values.push({
-                                periode: moment(ressource.periode, 'YYYY-MM').format('MMMM YYYY'),
+                                periode: moment(ressource.periode, 'YYYY-MM').format('MMMM YYYY'),
                                 montant: ressource.montant
                             });
                         }

--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -92,7 +92,7 @@ angular.module('ddsCommon').factory('SituationService', function($http, $session
                 refDate.add(1, 'months');
                 return {
                     id: refDate.format('YYYY-MM'),
-                    label: refDate.format('MMMM YYYY')
+                    label: refDate.format('MMMM YYYY')
                 };
             });
         },

--- a/app/styles/foyer/capture-montant-ressource.css
+++ b/app/styles/foyer/capture-montant-ressource.css
@@ -1,3 +1,77 @@
+.panel-montant h3 {
+    font-size: 14px;
+}
+
+.panel-montant h3 .short-label {
+    display: inline-block;
+    margin-right: 10px;
+}
+
+.panel-montant .panel-body {
+    padding: 10px;
+}
+
+.panel-montant .checkbox {
+    margin-bottom: 1em;
+}
+
+.panel-montant.indemnites {
+    border-color: #AC6C82;
+}
+
+.panel-montant.indemnites .panel-heading {
+    background-color: #e3ced5;
+}
+
+.panel-montant.pensions {
+    border-color: #685C79;
+}
+
+.panel-montant.pensions .panel-heading {
+    background-color: #eae7ed;
+}
+
+.panel-montant.allocations {
+    border-color: #DA727E;
+}
+
+.panel-montant.allocations .panel-heading {
+    background-color: #faebed;
+}
+
+.panel-montant.revenusActivite {
+    border-color: #FFBC67;
+}
+
+.panel-montant.revenusActivite .panel-heading {
+    background-color: #ffe9cd;
+}
+
+.panel-montant.autre {
+    border-color: #39747B;
+}
+
+.panel-montant.autre .panel-heading {
+    background-color: #cce4e7;
+}
+
+.panel-montant.rpns {
+    border-color: #8366d4;
+}
+
+.panel-montant.rpns .panel-heading {
+    background-color: #dad7e8;
+}
+
+.panel-montant.patrimoine {
+    border-color: #455C7B;
+}
+
+.panel-montant.patrimoine .panel-heading {
+    background-color: #d7dee8;
+}
+
+
 @media (min-width: 768px) {
     .ressources-values {
         display: flex;

--- a/app/styles/foyer/capture-montant-ressource.css
+++ b/app/styles/foyer/capture-montant-ressource.css
@@ -1,18 +1,5 @@
-.panel-montant h3 {
-    font-size: 14px;
-}
-
-.panel-montant h3 .short-label {
-    display: inline-block;
-    margin-right: 10px;
-}
-
-.panel-montant .panel-body {
-    padding: 10px;
-}
-
 .panel-montant .checkbox {
-    margin-bottom: 1em;
+    margin-top: .5em;
 }
 
 .panel-montant.indemnites {

--- a/app/styles/foyer/capture-montant-ressource.css
+++ b/app/styles/foyer/capture-montant-ressource.css
@@ -1,0 +1,6 @@
+@media (min-width: 768px) {
+    .ressources-values {
+        display: flex;
+        align-items: flex-end;
+    }
+}

--- a/app/styles/foyer/capture-montant-ressource.scss
+++ b/app/styles/foyer/capture-montant-ressource.scss
@@ -1,0 +1,8 @@
+@import '../commons';
+
+@media (min-width: $screen-sm-min) {
+  .ressources-values {
+    display: flex;
+    align-items: flex-end;
+  }
+}

--- a/app/styles/foyer/capture-montant-ressource.scss
+++ b/app/styles/foyer/capture-montant-ressource.scss
@@ -1,8 +1,0 @@
-@import '../commons';
-
-@media (min-width: $screen-sm-min) {
-  .ressources-values {
-    display: flex;
-    align-items: flex-end;
-  }
-}

--- a/app/styles/front.scss
+++ b/app/styles/front.scss
@@ -88,31 +88,24 @@ h1[tabindex="-1"] {
 
 $revenusActivite: #FFBC67;
 $revenusActivite-light: #ffd29a;
-$revenusActivite-lighter: #ffe9cd;
 
 $allocations: #DA727E;
 $allocations-light: #efc3c8;
-$allocations-lighter: #faebed;
 
 $indemnites: #AC6C82;
 $indemnites-light: #d1adb9;
-$indemnites-lighter: #e3ced5;
 
 $pensions: #685C79;
 $pensions-light: #cfcad7;
-$pensions-lighter: #eae7ed;
 
 $patrimoine: #455C7B;
 $patrimoine-light: #b6c4d6;
-$patrimoine-lighter: #d7dee8;
 
 $autre: #39747B;
 $autre-light: #a9d2d7;
-$autre-lighter: #cce4e7;
 
 $rpns: #8366d4;
 $rpns-light: #a8a1c8;
-$rpns-lighter: #dad7e8;
 
 .btn-default, .btn {
   &.active, &.active:focus, &.active:hover {
@@ -276,61 +269,6 @@ $rpns-lighter: #dad7e8;
     a {
       margin-bottom: 5px;
     }
-  }
-}
-
-@mixin panel-montant-variant($color-base, $color-light, $color-lighter) {
-  @include panel-variant($color-base, black, $color-lighter, $color-light);
-
-  h3 .short-label {
-    color: darken($color-base, 30%);
-  }
-}
-
-.panel.panel-montant {
-  h3 {
-    font-size: 14px;
-
-    .short-label {
-      display: inline-block;
-      margin-right: 10px;
-    }
-  }
-
-  .panel-body {
-    padding: 10px;
-  }
-
-  .checkbox {
-    margin-bottom: 1em;
-  }
-
-  &.indemnites {
-    @include panel-montant-variant($indemnites, $indemnites-light, $indemnites-lighter);
-  }
-
-  &.pensions {
-    @include panel-montant-variant($pensions, $pensions-light, $pensions-lighter);
-  }
-
-  &.allocations {
-    @include panel-montant-variant($allocations, $allocations-light, $allocations-lighter);
-  }
-
-  &.revenusActivite {
-    @include panel-montant-variant($revenusActivite, $revenusActivite-light, $revenusActivite-lighter);
-  }
-
-  &.autre {
-    @include panel-montant-variant($autre, $autre-light, $autre-lighter);
-  }
-
-  &.rpns {
-    @include panel-montant-variant($rpns, $rpns-light, $rpns-lighter);
-  }
-
-  &.patrimoine {
-    @include panel-montant-variant($patrimoine-light, $patrimoine-light, $patrimoine-lighter);
   }
 }
 

--- a/app/styles/front.scss
+++ b/app/styles/front.scss
@@ -279,13 +279,6 @@ $rpns-lighter: #dad7e8;
   }
 }
 
-@media (min-width: $screen-sm-min) {
-  .ressources-values {
-    display: flex;
-    align-items: flex-end;
-  }
-}
-
 @mixin panel-montant-variant($color-base, $color-light, $color-lighter) {
   @include panel-variant($color-base, black, $color-lighter, $color-light);
 

--- a/app/styles/front.scss
+++ b/app/styles/front.scss
@@ -279,6 +279,13 @@ $rpns-lighter: #dad7e8;
   }
 }
 
+@media (min-width: $screen-sm-min) {
+  .ressources-values {
+    display: flex;
+    align-items: flex-end;
+  }
+}
+
 @mixin panel-montant-variant($color-base, $color-light, $color-lighter) {
   @include panel-variant($color-base, black, $color-lighter, $color-light);
 

--- a/app/views/front.html
+++ b/app/views/front.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="/js/lib/font-awesome/css/font-awesome.min.css">
     <link rel="stylesheet" href="/styles/text-container.css">
     <link rel="stylesheet" href="/styles/enfants.css">
+    <link rel="stylesheet" href="/styles/foyer/capture-montant-ressource.css">
 
     <meta name="description" content="Ce questionnaire en ligne simple vous donnera un montant mensuel pour chaque prestation et vous donnera accès aux démarches.">
 

--- a/app/views/partials/foyer/capture-montant-ressource.html
+++ b/app/views/partials/foyer/capture-montant-ressource.html
@@ -1,9 +1,6 @@
 <div class="panel panel-montant {{ ressourceType.category }}">
   <div class="panel-heading">
-    <h3 class="panel-title">
-      <span class="short-label" ng-if="shortLabel">{{ shortLabel }}</span>
-      {{ ressourceType.label }}
-    </h3>
+    <h3 class="panel-title">{{ ressourceType.label }}</h3>
   </div>
   <div class="panel-body">
     <div class="row ressources-values">

--- a/app/views/partials/foyer/capture-montant-ressource.html
+++ b/app/views/partials/foyer/capture-montant-ressource.html
@@ -6,7 +6,7 @@
     </h3>
   </div>
   <div class="panel-body">
-    <div class="row">
+    <div class="row ressources-values">
       <div class="col-sm-3" ng-repeat="month in months">
         <label for="{{ ressource.type.id }}-month_{{ $index + 1 }}">
           {{ month.label|uppercaseFirst }}
@@ -30,7 +30,7 @@
       </div>
       <div class="col-sm-3">
         <label for="{{ ressource.type.id }}-year">
-          Total depuis {{ debutAnneeGlissante }}
+          Total de {{ debutAnneeGlissante }} à {{ months[months.length-1].label }}
         </label>
         <span class="input-group">
           <input

--- a/app/views/partials/foyer/capture-montant-ressource.html
+++ b/app/views/partials/foyer/capture-montant-ressource.html
@@ -30,7 +30,7 @@
       </div>
       <div class="col-sm-3">
         <label for="{{ ressource.type.id }}-year">
-          Total de {{ debutAnneeGlissante }} à {{ months[months.length-1].label }}
+          Total de {{ debutAnneeGlissante }} à {{ months[months.length-1].label }}&nbsp;inclus
         </label>
         <span class="input-group">
           <input

--- a/app/views/partials/foyer/individu-form.html
+++ b/app/views/partials/foyer/individu-form.html
@@ -183,8 +183,8 @@
       >
       <question ng-non-bindable><!-- We don't interpolate the following text, so that it can be re-interpolated several times if dateDernierContratTravail changes-->
         {{ individu.role == 'demandeur' ? 'Avez-vous' : 'A-t-il (elle)' }}
-        travaillé au moins 5&nbsp;ans entre&nbsp;{{ individu.dateDernierContratTravail.clone().subtract(10, 'years').format('MMMM YYYY') }}
-        et&nbsp;{{ individu.dateDernierContratTravail.format('MMMM YYYY') }}&nbsp;?
+        travaillé au moins 5&nbsp;ans entre&nbsp;{{ individu.dateDernierContratTravail.clone().subtract(10, 'years').format('MMMM YYYY') }}
+        et&nbsp;{{ individu.dateDernierContratTravail.format('MMMM YYYY') }}&nbsp;?
       </question>
       <help-block>1825&nbsp;jours (5&nbsp;fois&nbsp;365) couverts par un contrat de travail, en activité ou en congés.</help-block>
     </yes-no-question>

--- a/app/views/partials/foyer/ressources/detail-montants.html
+++ b/app/views/partials/foyer/ressources/detail-montants.html
@@ -13,7 +13,7 @@
   <div class="panel panel-montant rpns"
     ng-if="ressource.type.category == 'rpns' && ressource.type.id == 'tns_auto_entrepreneur_chiffre_affaires'">
     <div class="panel-heading">
-      <h3 class="panel-title"><span class="short-label">{{ label }}</span> {{ ressourceTypes[ressource.type.id].label }}</h3>
+      <h3 class="panel-title">{{ ressourceTypes[ressource.type.id].label }}</h3>
     </div>
     <div class="panel-body">
       <div class="row">
@@ -84,7 +84,7 @@
   <div class="panel panel-montant rpns"
     ng-if="ressource.type.category == 'rpns' && ressource.type.id == 'tns_micro_entreprise_chiffre_affaires'">
     <div class="panel-heading">
-      <h3 class="panel-title"><span class="short-label">{{ label }}</span> {{ ressourceTypes[ressource.type.id].label }}</h3>
+      <h3 class="panel-title">{{ ressourceTypes[ressource.type.id].label }}</h3>
     </div>
     <div class="panel-body">
       <div class="row">
@@ -122,7 +122,7 @@
 
   <div class="panel panel-montant rpns" ng-if="ressource.type.id == 'tns_autres_revenus'">
     <div class="panel-heading">
-      <h3 class="panel-title"><span class="short-label">{{ label }}</span> {{ ressourceTypes[ressource.type.id].label }}</h3>
+      <h3 class="panel-title">{{ ressourceTypes[ressource.type.id].label }}</h3>
     </div>
     <div class="panel-body">
       <div class="row">
@@ -163,7 +163,7 @@
   <div class="panel panel-montant rpns"
     ng-if="ressource.type.id == 'tns_benefice_exploitant_agricole'">
     <div class="panel-heading">
-      <h3 class="panel-title"><span class="short-label">{{ label }}</span> {{ ressourceTypes[ressource.type.id].label }}</h3>
+      <h3 class="panel-title">{{ ressourceTypes[ressource.type.id].label }}</h3>
     </div>
     <div class="panel-body">
       <div class="row">


### PR DESCRIPTION
En l'état, ça donne ça.

![capture d ecran 2017-06-01 a 19 25 01](https://cloud.githubusercontent.com/assets/1410356/26692196/1577f980-4700-11e7-9af0-22233f26c8ad.png)


Ça me va mais je me demande s'il ne faudrait pas :
- à minima, un espace insécable entre "mai" et "2017" pour éviter l'orphelin sur une nouvelle ligne,
- peut-être un espace insécable entre "à" et "mai",
- ou encore ajouter "inclus" à la fin (avec un espace insécable là encore).
