### PR TITLE
Fix error handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,9 @@ module.exports = function(app) {
         res.sendFile(viewsDirectory + '/front.html');
     });
 
-    app.use(function (err, req, res) {
-        if (err) return res.status(err.code || 500).send(err);
+    app.use(function (err, req, res, next) {
+        console.error(err);
+        res.status(parseInt(err.code) || 500).send(err);
+        next();
     });
 };


### PR DESCRIPTION
A 4-parameter middleware is required to handle errors
http://expressjs.com/en/guide/error-handling.html



Multiple errors on production
```
TypeError: res.status is not a function
    at /home/main/mes-aides-ui/index.js:67:29
    at Layer.handle [as handle_request] (/home/main/mes-aides-ui/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/main/mes-aides-ui/node_modules/express/lib/router/index.js:317:13)
    at /home/main/mes-aides-ui/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/home/main/mes-aides-ui/node_modules/express/lib/router/index.js:335:12)
    at next (/home/main/mes-aides-ui/node_modules/express/lib/router/index.js:275:10)
    at serveStatic (/home/main/mes-aides-ui/node_modules/serve-static/index.js:75:16)
    at Layer.handle [as handle_request] (/home/main/mes-aides-ui/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/main/mes-aides-ui/node_modules/express/lib/router/index.js:317:13)
    at /home/main/mes-aides-ui/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/home/main/mes-aides-ui/node_modules/express/lib/router/index.js:335:12)
    at next (/home/main/mes-aides-ui/node_modules/express/lib/router/index.js:275:10)
    at favicon (/home/main/mes-aides-ui/node_modules/serve-favicon/index.js:67:7)
    at Layer.handle [as handle_request] (/home/main/mes-aides-ui/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/main/mes-aides-ui/node_modules/express/lib/router/index.js:317:13)
    at /home/main/mes-aides-ui/node_modules/express/lib/router/index.js:284:7
```
