### PR TITLE
Préciser où trouver les revenus Y-2

### DIFF
--- a/app/js/controllers/foyer/yearMoins2.js
+++ b/app/js/controllers/foyer/yearMoins2.js
@@ -4,6 +4,7 @@ angular.module('ddsApp').controller('FoyerRessourceYearMoins2Ctrl', function($sc
     var today = $scope.situation.dateDeValeur;
     var months = MonthService.getMonths(today, 12);
     $scope.yearMoins2 = moment(today).subtract('years', 2).format('YYYY');
+    $scope.yearMoins1 = moment($scope.situation.dateDeValeur).subtract('years', 1).format('YYYY');
     $scope.debutAnneeGlissante = moment(today).subtract('years', 1).format('MMMM YYYY');
 
     $scope.individuRefsToDisplay = [];

--- a/app/views/partials/foyer/ressources/year-moins-2.html
+++ b/app/views/partials/foyer/ressources/year-moins-2.html
@@ -1,8 +1,8 @@
 <div class="frame-foyer">
   <h1>Les revenus imposables de votre foyer en {{ yearMoins2 }}</h1>
   <p>
-    Ces informations se trouvent sur votre déclaration de revenus d'impôts {{ yearMoins2 }}.
-    <br>Vous pouvez la retrouver en ligne sur <a href="http://www.impots.gouv.fr/">impots.gouv.fr</a>.
+    Ces informations se trouvent sur votre avis d'imposition {{ yearMoins1 }} sur les revenus {{ yearMoins2 }}.
+    <br>Vous pouvez le retrouver en ligne sur <a href="http://www.impots.gouv.fr/">impots.gouv.fr</a>.
   </p>
   <form class="form-horizontal" novalidate name="form" ng-submit="submit(form)">
     <div class="row">

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,9 @@ machine:
 dependencies:
   post:
     - npm install saucelabs@0.1.1 # allow sending Watai results to SauceLabs
-    - wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz
-    - tar -xzf sc-latest-linux.tar.gz
+    # https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy
+    - wget https://saucelabs.com/downloads/sc-4.4.9-linux.tar.gz
+    - tar -xzf sc-4.4.9-linux.tar.gz
     - virtualenv --python=python2 ~/virtualenv
     - source ~/virtualenv/bin/activate && pip install --upgrade pip
     - source ~/virtualenv/bin/activate && pip install gunicorn


### PR DESCRIPTION
Par tradition en France, même si tout le monde conserve tous ses documents, on regarde en premier les avis d'imposition, décalés d'une année, avant les déclarations. Cette PR explicite où trouver les revenus demandés pour Y-2.