### PR TITLE
Allow aide customization

### DIFF
--- a/app/js/constants/droits.js
+++ b/app/js/constants/droits.js
@@ -162,6 +162,11 @@ var droitsDescription = {
                             'reason': 'votre conjoint·e a des revenus en tant qu’indépendant·e',
                             'solution': 'Vous pouvez demander à bénéficier du RSA, mais c’est le président de votre conseil départemental qui <a target="_blank" rel="noopener" title="Article R262-23 du code de l’action sociale" href="https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000028251799&cidTexte=LEGITEXT000006074069">décidera</a> de la manière dont les revenus non salariés de votre conjoint·e impacteront le montant de votre aide.'
                         }
+                    },
+                    customization: {
+                        'D93-SSD': {
+                            link: 'https://www.seine-saint-denis.fr/IMG/pdf/guide_rsa_a5_8p-2014.pdf'
+                        }
                     }
                 },
                 'aide_logement': {

--- a/app/js/services/customizationService.js
+++ b/app/js/services/customizationService.js
@@ -1,0 +1,17 @@
+'use strict';
+
+angular.module('ddsCommon').factory('CustomizationService', function() {
+
+    function determineCustomizationId(testCase, currentPeriod) {
+        if (testCase.menages &&
+            testCase.menages[0] &&
+            testCase.menages[0].depcom[currentPeriod].match(/^93/))
+            return 'D93-SSD';
+
+        return undefined;
+    }
+
+    return {
+        determineCustomizationId: determineCustomizationId,
+    };
+});

--- a/app/js/services/resultatService.js
+++ b/app/js/services/resultatService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('ddsApp').service('ResultatService', function($http, droitsDescription) {
+angular.module('ddsApp').service('ResultatService', function($http, droitsDescription, CustomizationService) {
 
     /**
     *@param    {String}  An Openfisca period. For example: 'month:2014-12'.
@@ -21,9 +21,11 @@ angular.module('ddsApp').service('ResultatService', function($http, droitsDescri
     }
 
     function normalizeSituation(openfiscaSituation) {
+        var period = normalizePeriod(openfiscaSituation.period);
         return {
-            period: normalizePeriod(openfiscaSituation.period),
+            period: period,
             ressources: normalizeRessources(openfiscaSituation.test_case),
+            customizationId: CustomizationService.determineCustomizationId(openfiscaSituation.test_case, period),
         };
     }
 
@@ -65,7 +67,8 @@ angular.module('ddsApp').service('ResultatService', function($http, droitsDescri
                         {
                             montant: value,
                             provider: aidesProvider,
-                        }
+                        },
+                        situation.customizationId && aide.customization && aide.customization[situation.customizationId]
                     );
                 });
 

--- a/app/views/front.html
+++ b/app/views/front.html
@@ -152,6 +152,7 @@
     <script src="js/services/resultatService.js"></script>
     <script src="js/services/individuService.js"></script>
     <script src="js/services/ressourceService.js"></script>
+    <script src="js/services/customizationService.js"></script>
 
     <script src="js/directives/date.js"></script>
     <script src="js/directives/selectOnFocus.js"></script>


### PR DESCRIPTION
Results displayed at the end of a simulation can be customized.

* The `customizationService` determines the **customizationId** and
* the `resultService` fetches override default data when relevant.


This change is linked to a request from Seine Saint Denis, it includes a customization of a link for the RSA for users living in a Seine Saint Denis city.