### PR TITLE
Prevent consistency error due to bogus operations on float

### DIFF
--- a/app/js/directives/captureMontantRessource.js
+++ b/app/js/directives/captureMontantRessource.js
@@ -35,9 +35,9 @@ angular.module('ddsApp').directive('captureMontantRessource', function(Situation
             scope.onGoingLabel = getOnGoingQuestion(scope.individu, scope.ressourceType, scope.currentMonth);
 
             function checkSumConsistency() {
-                scope.monthsSum = scope.ressource.montantsMensuels.reduce(function(sum, current) {
+                scope.monthsSum = _.round(scope.ressource.montantsMensuels.reduce(function(sum, current) {
                     return sum + current;
-                }, 0);
+                }, 0), 2);
 
                 ngModel.$setValidity('valuesConsistency', scope.ressource.montantAnnuel >= scope.monthsSum);
             }


### PR DESCRIPTION
This PR mitigates a bug in the ressource view.

Operations on float are bogus:
* 0.1 + 0.2 != 0.3 (and more precisely 0.1 + 0.2 > 0.3)


