### PR TITLE
Prompt and validate date arret de travail

### DIFF
--- a/app/js/directives/captureMontantRessource.js
+++ b/app/js/directives/captureMontantRessource.js
@@ -53,7 +53,7 @@ angular.module('ddsApp').directive('captureMontantRessource', function(MonthServ
 
             scope.shouldAskDateArretDeTravail = function() {
                 // If there is no IJSS the first month, we know the arret de travail is recent and don't need to capture the date.
-                return ['indemnites_journalieres_maladie', 'indemnites_journalieres_maladie_professionnelle', 'indemnites_journalieres_accident_travail'].indexOf(scope.ressourceType.id) >= 0 && scope.ressource[scope.months[0]];
+                return ['indemnites_journalieres_maladie', 'indemnites_journalieres_maladie_professionnelle', 'indemnites_journalieres_accident_travail'].indexOf(scope.ressourceType.id) >= 0 && scope.ressource[scope.months[0].id];
             };
         }
     };

--- a/app/views/partials/foyer/capture-montant-ressource.html
+++ b/app/views/partials/foyer/capture-montant-ressource.html
@@ -90,6 +90,7 @@
         format="JJ/MM/AAAA"
         class="form-control"
         min="{{ individu.date_naissance }}"
+        max="{{ dateDeValeur }}"
         name="dateArretDeTravail"
         id="date-arret-travail"
         required
@@ -105,6 +106,9 @@
         </li>
         <li ng-if="form.dateArretDeTravail.$error.isBeforeMin">
           Il semblerait qu'on vous ait prescrit un arrêt de travail avant votre naissance.
+        </li>
+        <li ng-if="form.dateArretDeTravail.$error.isAfterMax">
+          Le simulateur ne permet pas d'indiquer un arrêt de travail dans le futur.
         </li>
       </ul>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sgmap-mes-aides-ui",
   "description": "Simulateur de prestations sociales mes-aides.gouv.fr",
-  "version": "12.0.2",
+  "version": "12.0.3",
   "dependencies": {
     "angulartics": "^1.3.0",
     "angulartics-piwik": "^1.0.4",


### PR DESCRIPTION
* date_arret_de_travail was not displayed because of the recent refactoring

Fixes #591