### PR TITLE
Improve situation migration script

### DIFF
--- a/backend/lib/migrations/initial.js
+++ b/backend/lib/migrations/initial.js
@@ -55,6 +55,10 @@ exports.persistedSituationPretransformationUpdate = function persistedSituationP
                 ressource.type = newName;
             }
         });
+
+        individu.specificSituations = individu.specificSituations.map(function(specificSituation) {
+            return specificSituation.situation || specificSituation;
+        });
     });
 
     if (situation.logement.loyer === null) {

--- a/backend/lib/migrations/initial.js
+++ b/backend/lib/migrations/initial.js
@@ -81,6 +81,10 @@ exports.persistedSituationPretransformationUpdate = function persistedSituationP
             type: 'frais_reels',
         });
     }
+
+    if (situation.ressourcesYearMoins2Captured === false && this.ressourcesYearMoins2Captured(situation)) {
+        situation.ressourcesYearMoins2Captured = true;
+    }
 };
 
 exports.migratePersistedSituation = function(sourceSituation) {

--- a/backend/lib/migrations/initial.js
+++ b/backend/lib/migrations/initial.js
@@ -135,11 +135,16 @@ exports.migratePersistedSituation = function(sourceSituation) {
             }
         }
 
-        individu.scolarite = {
-            inconnue: 'Inconnue',
-            college: 'Collège',
-            lycee: 'Lycée',
-        }[sourceIndividu.scolarite];
+        if (sourceIndividu.scolarite) {
+            var scolariteMapping = {
+                inconnue: 'Inconnue',
+                college: 'Collège',
+                lycee: 'Lycée',
+            };
+            if (scolariteMapping[sourceIndividu.scolarite]) {
+                individu.scolarite = scolariteMapping[sourceIndividu.scolarite];
+            }
+        }
 
         individu.taux_incapacite = {
             moins50: 0.3,


### PR DESCRIPTION
The script was created focusing on situations used in tests (~600 situations).
Amendments are required to manage all the situations that need to be migrated.

The script as is in this PR migrate all but one situations with `status` = `test` (~10000 situations).
The script moves situations from the legacysituations table to the situations table on success.