### PR TITLE
Add Last contract date validation and persistence

### DIFF
--- a/app/views/partials/foyer/individu-form.html
+++ b/app/views/partials/foyer/individu-form.html
@@ -152,6 +152,7 @@
             dds-date
             format="MM/AAAA"
             min="{{ individu.date_naissance }}"
+            max="{{ situation.dateDeValeur }}"
             name="dateDernierContratTravail"
             id="last-job-end-date"
             ng-model="individu.dateDernierContratTravail"
@@ -163,6 +164,9 @@
           </li>
           <li ng-if="form.dateDernierContratTravail.$error.isBeforeMin">
             Il semblerait que votre contrat de travail se soit arrêté avant votre naissance.
+          </li>
+          <li ng-if="form.dateDernierContratTravail.$error.isAfterMax">
+            Le simulateur ne permet pas d'indiquer une date de fin de travail dans le futur.
           </li>
         </ul>
       </div>

--- a/backend/lib/openfisca/mapping/individu/index.js
+++ b/backend/lib/openfisca/mapping/individu/index.js
@@ -85,6 +85,7 @@ function buildOpenFiscaIndividu(mesAidesIndividu, situation) {
     proxyAnneeDeReferenceRessources(openFiscaIndividu, situation);
 
     var propertiesToDelete = [
+        'dateDernierContratTravail',
         'firstName',
         'nationalite',
         'role',

--- a/backend/lib/openfisca/mapping/individu/index.js
+++ b/backend/lib/openfisca/mapping/individu/index.js
@@ -84,9 +84,10 @@ function buildOpenFiscaIndividu(mesAidesIndividu, situation) {
     individuRessource.computeRessources(mesAidesIndividu, openFiscaIndividu);
     proxyAnneeDeReferenceRessources(openFiscaIndividu, situation);
 
+    // Variables stored to properly restore UI
     var propertiesToDelete = [
-        'dateDernierContratTravail',
-        'firstName',
+        'dateDernierContratTravail', // for ass_precondition_remplie
+        'firstName', // for kids
         'nationalite',
         'role',
         'salaire_net_hors_revenus_exceptionnels',

--- a/backend/models/situation.js
+++ b/backend/models/situation.js
@@ -43,6 +43,7 @@ var individuDef = Object.assign({
     ass_precondition_remplie: Boolean,
     boursier: Boolean,
     date_arret_de_travail: Date,
+    dateDernierContratTravail: Date,
     date_naissance: Date,
     echelon_bourse: Number,
     enfant_a_charge: Object,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sgmap-mes-aides-ui",
   "description": "Simulateur de prestations sociales mes-aides.gouv.fr",
-  "version": "12.0.4",
+  "version": "12.1.0",
   "dependencies": {
     "angulartics": "^1.3.0",
     "angulartics-piwik": "^1.0.4",


### PR DESCRIPTION
During the upgrade the `dateDernierContratTravail` was removed from the situation schema.

That PR adds it back so that it is persisted and the UI is properly restored.

This PR also includes an additional validation on that value so that is never in the future.