### PR TITLE
Display a warning on result page w/o a valid situation

### DIFF
--- a/app/js/controllers/foyer.js
+++ b/app/js/controllers/foyer.js
@@ -3,9 +3,23 @@
 angular.module('ddsApp').controller('FoyerCtrl', function($scope, $state, $stateParams, $filter, $location, SituationService, IndividuService) {
     var situation = $scope.situation = SituationService.restoreLocal();
 
-    $scope.$on('setSituation', function(e, newSituation) {
-        situation = $scope.situation = newSituation;
-    });
+    $scope.restoreRemoteSituation = function(situationId) {
+        return SituationService.restoreRemote(situationId)
+        .then(function(persistedSituation) {
+            situation = $scope.situation = persistedSituation;
+            $scope.$broadcast('newSituation');
+            return situation;
+        });
+    };
+
+    $scope.persistLocalSituation = function() {
+        return SituationService.save(situation).then(function(situation) { return situation._id; })
+        .then(SituationService.restoreRemote)
+        .then(function(persistedSituation) {
+            situation = $scope.situation = persistedSituation;
+            return situation;
+        });
+    };
 
     $scope.statutsSpecifiques = IndividuService.formatStatutsSpecifiques;
     $scope.nationalite = IndividuService.nationaliteLabel;

--- a/app/js/controllers/foyer/recapSituation.js
+++ b/app/js/controllers/foyer/recapSituation.js
@@ -1,8 +1,9 @@
 'use strict';
 
 angular.module('ddsCommon').controller('RecapSituationCtrl', function($scope, $state, nationalites, ressourceTypes, patrimoineTypes, categoriesRnc, CityService, SituationService, IndividuService, LogementService, MonthService, RessourceService) {
-    $scope.yearMoins1 = moment($scope.situation.dateDeValeur).subtract('years', 1).format('YYYY');
-    $scope.yearMoins2 = moment($scope.situation.dateDeValeur).subtract('years', 2).format('YYYY');
+    $scope.keyedRessourceTypes = _.keyBy(ressourceTypes, 'id');
+    $scope.categoriesRnc = categoriesRnc;
+    $scope.getIndividuRessourcesHeader = IndividuService.ressourceHeader;
 
     function buildRecapLogement () {
         var logementLabels = LogementService.getLabels($scope.situation.menage.statut_occupation_logement);
@@ -10,8 +11,6 @@ angular.module('ddsCommon').controller('RecapSituationCtrl', function($scope, $s
         $scope.loyerLabel = logementLabels.loyerLabel;
         $scope.recapLogement = logementLabels.recapLogement;
     }
-    $scope.keyedRessourceTypes = _.keyBy(ressourceTypes, 'id');
-    $scope.categoriesRnc = categoriesRnc;
 
     function getRessources (individu) {
         return ressourceTypes.reduce(function(accum, ressource) {
@@ -69,11 +68,6 @@ angular.module('ddsCommon').controller('RecapSituationCtrl', function($scope, $s
             });
         $scope.ressourcesYearMoins2Captured = SituationService.ressourcesYearMoins2Captured($scope.situation);
     }
-    $scope.ressourcesYearMoins2Captured = SituationService.ressourcesYearMoins2Captured($scope.situation);
-
-    $scope.months = MonthService.getMonths($scope.situation.dateDeValeur);
-
-    $scope.getIndividuRessourcesHeader = IndividuService.ressourceHeader;
 
     $scope.getRessourceByType = function (typeName) {
         return _.find(ressourceTypes, { id: typeName });
@@ -102,25 +96,30 @@ angular.module('ddsCommon').controller('RecapSituationCtrl', function($scope, $s
         return 'foyer.ressources.individu.' + page + '({individu: ' + index + '})';
     };
 
-    if ($scope.situation.menage && $scope.situation.menage.statut_occupation_logement) {
-        buildRecapLogement();
-    }
-
     $scope.$on('logementCaptured', buildRecapLogement);
-
-    prepareRecapRessources();
-    $scope.ressourcesCaptured = $scope.haveRessourcesDeclared || Boolean($scope.situation._id);
-
     $scope.$on('ressourcesUpdated', buildRecapRessources);
-
-    if ($scope.ressourcesYearMoins2Captured) {
-        buildYm2Recap();
-    }
-
     $scope.$on('ym2Captured', buildYm2Recap);
-
-    buildRecapPatrimoine();
-
     $scope.$on('patrimoineCaptured', buildRecapPatrimoine);
 
+    function refreshFullView() {
+
+        $scope.yearMoins1 = moment($scope.situation.dateDeValeur).subtract('years', 1).format('YYYY');
+        $scope.yearMoins2 = moment($scope.situation.dateDeValeur).subtract('years', 2).format('YYYY');
+        $scope.ressourcesYearMoins2Captured = SituationService.ressourcesYearMoins2Captured($scope.situation);
+        $scope.months = MonthService.getMonths($scope.situation.dateDeValeur);
+
+        if ($scope.situation.menage && $scope.situation.menage.statut_occupation_logement) {
+            buildRecapLogement();
+        }
+        prepareRecapRessources();
+        $scope.ressourcesCaptured = $scope.haveRessourcesDeclared || Boolean($scope.situation._id);
+        if ($scope.ressourcesYearMoins2Captured) {
+            buildYm2Recap();
+        }
+        buildRecapPatrimoine();
+
+    }
+
+    $scope.$on('newSituation', refreshFullView);
+    refreshFullView();
 });

--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -21,6 +21,11 @@ angular.module('ddsCommon').factory('SituationService', function($http, $session
         return situation;
     }
 
+    function saveLocally(persistedSituation) {
+        situation = $sessionStorage.situation = persistedSituation;
+        return adaptPersistedSituation(persistedSituation);
+    }
+
     return {
         newSituation: function() {
             situation = $sessionStorage.situation = {
@@ -47,12 +52,9 @@ angular.module('ddsCommon').factory('SituationService', function($http, $session
         restoreRemote: function(situationId) {
             return $http.get('/api/situations/' + situationId, {
                 params: { cacheBust: Date.now() }
-            }).then(function(result) {
-                situation = result.data;
-                $sessionStorage.situation = situation;
-
-                return situation;
-            }).then(adaptPersistedSituation);
+            })
+            .then(function(result) { return result.data; })
+            .then(saveLocally);
         },
 
         save: function(situation) {
@@ -61,10 +63,8 @@ angular.module('ddsCommon').factory('SituationService', function($http, $session
                 delete situation._id;
             }
             return $http.post('/api/situations/', situation)
-            .then(function(result) {
-                situation._id = result.data._id;
-                return result.data;
-            }).then(adaptPersistedSituation);
+            .then(function(result) { return result.data; })
+            .then(saveLocally);
         },
 
         getDemandeur: function(situation) {

--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -67,6 +67,14 @@ angular.module('ddsCommon').factory('SituationService', function($http, $session
             .then(saveLocally);
         },
 
+        /**
+        *@param    {String}  A situation model to send to the backend
+        *@return   {String}  A boolean indicating whether the situation looks ready for OpenFisca or not
+        */
+        passSanityCheck: function(situation) {
+            return situation.individus && situation.individus.length;
+        },
+
         getDemandeur: function(situation) {
             return _.find(situation.individus, { role: 'demandeur' });
         },

--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -2,6 +2,13 @@
 
 <p ng-if="awaitingResults"><i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Calcul en cours de vos droits…</p>
 
+<div id="warning" class="alert alert-warning" ng-if="warning" role="alert">
+  <h2><i class="fa fa-warning" aria-hidden="true"></i> Aucun résultat disponible</h2>
+  <p>
+    Pour commencer votre simulation, rendez-vous sur la <a ui-sref="home">page d'accueil</a>.
+  </p>
+</div>
+
 <div id="error" class="alert alert-danger" ng-if="error" role="alert">
   <h2><i class="fa fa-warning" aria-hidden="true"></i> Une erreur est survenue.</h2>
   <p><a analytics-on="click" analytics-event="Support" href="mailto:bug@mes-aides.gouv.fr?subject=[{{ situation._id }}]%20Probleme%20technique&body=Bonjour%2c%0d%0a%0d%0aJ%27ai%20tent%c3%a9%20de%20XXX%2c%0d%0aEt%20en%20cliquant%20sur%20XXX%2c%0d%0aJ%27ai%20rencontr%c3%a9%20l%27erreur%20ci-dessous.%0d%0a%0d%0aJe%20vous%20joins%20%c3%a9galement%20une%20capture%20d%27%c3%a9cran%20pour%20faciliter%20la%20compr%c3%a9hension%20du%20probl%c3%a8me.%0d%0a%0d%0a%e2%80%94%e2%80%94%e2%80%94%e2%80%94%0d%0aID%20%3a%20{{ situation._id }}%0d%0aUser-agent%20%3a%20{{ encodedUserAgent }}%0d%0aErreur%20%3a%20{{ encodedError }}%0d%0a%e2%80%94%e2%80%94%e2%80%94%e2%80%94">Signalez ce problème</a> en décrivant ce que vous faisiez avant que cette erreur n'apparaisse, et en joignant si possible une capture d'écran. Nous vous répondrons au plus vite et corrigerons le problème dès que possible.</p>
@@ -14,7 +21,7 @@
   </small>
 </div>
 
-<div ng-if="!error && !awaitingResults">
+<div ng-if="! error && ! warning && ! awaitingResults">
 
   <div ng-if="! (droits.prestationsNationales | isEmpty)">
     <p>D'après la situation que vous avez décrite, vous êtes a priori éligible à ces aides <strong>{{ droits.partenairesLocaux ? "nationales" : "" }}</strong> : </p>


### PR DESCRIPTION
Before #628, invalid situations (with individuals) were blocked in Angular because of an exception in the front.

Following that change, all situations were sent to OpenFisca and a error message was displayed.

With this PR, the error message is replaced with a warning with a CTA to go to the homepage.


