### PR TITLE
Display pensions alimentaires

### DIFF
--- a/app/js/controllers/foyer/recapSituation.js
+++ b/app/js/controllers/foyer/recapSituation.js
@@ -13,9 +13,11 @@ angular.module('ddsCommon').controller('RecapSituationCtrl', function($scope, $s
     }
 
     function getRessources (individu) {
-        return ressourceTypes.reduce(function(accum, ressource) {
-            if (individu[ressource.id] && _.some(individu[ressource.id])) {
-                accum[ressource.id] = individu[ressource.id];
+        return _
+        .keys(RessourceService.extractIndividuSelectedRessourceTypes(individu))
+        .reduce(function(accum, ressourceId) {
+            if (individu[ressourceId] && _.some(individu[ressourceId])) {
+                accum[ressourceId] = individu[ressourceId];
             }
             return accum;
         }, {});

--- a/app/js/controllers/foyer/recapSituation.js
+++ b/app/js/controllers/foyer/recapSituation.js
@@ -82,7 +82,7 @@ angular.module('ddsCommon').controller('RecapSituationCtrl', function($scope, $s
     }
 
     $scope.getTotalAnnuel = function (ressource) {
-        return ressource[$scope.yearMoins1] || ressource[$scope.yearMoins2] || getLast12MonthTotal(ressource);
+        return ressource[$scope.yearMoins1] || getLast12MonthTotal(ressource);
     };
 
     $scope.shouldDisplayPersonRessourcesRecap = function (individu) {

--- a/app/js/services/ressourceService.js
+++ b/app/js/services/ressourceService.js
@@ -44,9 +44,9 @@ angular.module('ddsCommon').factory('RessourceService', function(MonthService, c
     }
 
     function isRessourceOnMainScreen(ressourceOrType) {
-        // Make this function robust so that it can be called with a ressource from individu.ressources, a type from the ressourceTypes constant, or just a string.
-        var type = ressourceOrType.type || ressourceOrType.id || ressourceOrType;
-        return type != 'pensions_alimentaires_versees_individu' && ! _.find(categoriesRnc, { id: type });
+        // Make this function robust so that it can be called with a type from the ressourceTypes constant, or just a string.
+        var type = ressourceOrType.id || ressourceOrType;
+        return type != 'pensions_alimentaires_versees_individu';
     }
 
     function getMainScreenRessources(individu) {

--- a/app/js/services/ressourceService.js
+++ b/app/js/services/ressourceService.js
@@ -30,14 +30,20 @@ angular.module('ddsCommon').factory('RessourceService', function(MonthService, c
         }
     }
 
+    function isSelectedForCurrentYear(ressource, ressourceType) {
+        if (ressourceType.id != 'pensions_alimentaires_percues') {
+            return Boolean(ressource);
+        }
+
+        return _.keys(ressource).length > 1;
+    }
+
     function extractIndividuSelectedRessourceTypes(individu) {
         var result = {};
         _.chain(ressourceTypes)
-            .map('id')
-            .uniq()
             .filter(isRessourceOnMainScreen)
-            .filter(function(ressourceType) { return individu[ressourceType]; })
-            .forEach(function(ressourceType) { result[ressourceType] = true; })
+            .filter(function(ressourceType) { return isSelectedForCurrentYear(individu[ressourceType.id], ressourceType); })
+            .forEach(function(ressourceType) { result[ressourceType.id] = true; })
             .value();
 
         return result;

--- a/test/spec/controllers/foyer/ressources/enfants.js
+++ b/test/spec/controllers/foyer/ressources/enfants.js
@@ -11,7 +11,10 @@ describe('Controller: FoyerRessourcesEnfantsCtrl', function() {
                     { role: 'demandeur' },
                     { role: 'conjoint' },
                     { id: 'enfant_0', role: 'enfant', firstName: 'Jérome' },
-                    { id: 'enfant_1', role: 'enfant', firstName: 'Tom', primes_salaires_net: { '2012-12': 42 } },
+                    { id: 'enfant_1', role: 'enfant', firstName: 'Tom', primes_salaires_net: {
+                        '2012-11': 42,
+                        '2012-12': 42,
+                    } },
                 ],
             }
         };

--- a/test/spec/services/ressourceService.js
+++ b/test/spec/services/ressourceService.js
@@ -43,32 +43,19 @@ describe('RessourceService', function () {
 
     describe('isRessourceOnMainScreen', function() {
         it('should filter pensions alimentaires versées and RNC resources', function() {
-            var types = ['salaire_net_hors_revenus_exceptionnels', 'pensions_alimentaires_versees_individu', 'chomage_imposable'];
-            var ressources = [
-                {
-                    'type': 'pensions_invalidite',
-                },
-                {
-                    'type': 'pensions_alimentaires_versees_individu',
-                },
-                {
-                    'type': 'frais_reels',
-                }
-            ];
+            var types = ['salaire_net_hors_revenus_exceptionnels', 'pensions_alimentaires_versees_individu'];
             var ressourcesTypes = [
                 {
-                    id: 'pensions_invalidite',
+                    id: 'pensions_alimentaires_percues',
                 },
                 {
                     id: 'pensions_alimentaires_versees_individu',
                 }
             ];
             var filteredTypes = types.filter(service.isRessourceOnMainScreen);
-            var filteredRessources = ressources.filter(service.isRessourceOnMainScreen);
             var filteredRessourcesTypes = ressourcesTypes.filter(service.isRessourceOnMainScreen);
             expect(filteredTypes).toEqual(['salaire_net_hors_revenus_exceptionnels']);
-            expect(filteredRessources).toEqual([ { 'type': 'pensions_invalidite' } ]);
-            expect(filteredRessourcesTypes).toEqual([ { 'id': 'pensions_invalidite' } ]);
+            expect(filteredRessourcesTypes).toEqual([ { 'id': 'pensions_alimentaires_percues' } ]);
         });
     });
 

--- a/test/spec/services/ressourceService.js
+++ b/test/spec/services/ressourceService.js
@@ -73,7 +73,10 @@ describe('RessourceService', function () {
             var selectedTypes = service.extractIndividuSelectedRessourceTypes(individu);
 
             // then
-            expect(selectedTypes).toEqual({ salaire_net_hors_revenus_exceptionnels: true, indemnites_stage: true });
+            expect(selectedTypes).toEqual({
+                salaire_net_hors_revenus_exceptionnels: true,
+                indemnites_stage: true,
+            });
         });
 
         it('should not map pensions alimentaires versées to the view model', function() {
@@ -81,6 +84,7 @@ describe('RessourceService', function () {
             var individu = {
                 pensions_alimentaires_versees_individu: {
                     '2012-10': 100,
+                    '2012-11': 100,
                 },
             };
 
@@ -104,6 +108,42 @@ describe('RessourceService', function () {
 
             // then
             expect(selectedTypes).toEqual({ tns_micro_entreprise_chiffre_affaires: true });
+        });
+
+        describe('specific behavior of ym2 ressources', function() {
+
+            it('should capture monthly declaration', function() {
+                // given
+                var individu = {
+                    pensions_alimentaires_percues: {
+                        '2015-01': 41,
+                        '2015-02': 42,
+                    },
+                };
+
+                // when
+                var selectedTypes = service.extractIndividuSelectedRessourceTypes(individu);
+
+                // then
+                expect(selectedTypes).toEqual({
+                    pensions_alimentaires_percues: true,
+                });
+            });
+
+            it('should not capture yearly declaration', function() {
+                // given
+                var individu = {
+                    pensions_alimentaires_percues: {
+                        '2015': 41,
+                    },
+                };
+
+                // when
+                var selectedTypes = service.extractIndividuSelectedRessourceTypes(individu);
+
+                // then
+                expect(selectedTypes).toEqual({});
+            });
         });
     });
 });


### PR DESCRIPTION
Fix a bug introduced in #628.

Pensions alimentaires are in current year and YM2 resources but it was not possible to select it for the current year.

The logic was amended to fix that issue.