### PR TITLE
Rely on 2.0.3 version of OpenFisca Paris

### DIFF
--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,6 +1,6 @@
 gunicorn>=19.1.1
 openfisca_web_api==6.1.0
 openfisca_france==18.6.5
-git+https://github.com/sgmap/openfisca-paris.git@1ed92feee5233a7378759f8a05ee7fd48b48c7a2#egg=openfisca-paris
+git+https://github.com/sgmap/openfisca-paris.git@20868e3b36ed6c641f3ba3f97ac58abfb61b47b1#egg=openfisca-paris
 git+https://github.com/sgmap/openfisca-cd93.git@952225f1fd13ad664b07b0de8e2e584e47bee34e#egg=openfisca-cd93
 git+https://github.com/sgmap/openfisca-rennesmetropole.git@17a37d35abaa792f3efb29aa0719df19059c4b0d#egg=openfisca-RennesMetropole


### PR DESCRIPTION
Take all aide_logement into account to compute de Paris taux d'effort.