### PR TITLE
Fix resource continuation checkbox behavior

### DIFF
--- a/app/js/services/ressourceService.js
+++ b/app/js/services/ressourceService.js
@@ -29,6 +29,11 @@ angular.module('ddsCommon').factory('RessourceService', function(MonthService, c
         individu[ressourceId] = individu[ressourceId] || {};
         var ressource = individu[ressourceId];
         var periodKeys = getPeriodKeysForCurrentYear(dateDeValeur, ressourceType);
+
+        if (_.some(periodKeys, function(periodKey) { return _.isNumber(ressource[periodKey]); })) {
+            return;
+        }
+
         periodKeys.forEach(function(periodKey) {
             ressource[periodKey] = ressource[periodKey] || 0;
         });

--- a/test/spec/services/ressourceService.js
+++ b/test/spec/services/ressourceService.js
@@ -36,6 +36,28 @@ describe('RessourceService', function () {
         });
     });
 
+    describe('setDefaultValueForCurrentYear', function() {
+        it('should provide 13 zeros by default', function() {
+            var individu = {};
+            var periodKeys = service.setDefaultValueForCurrentYear(dateDeValeur, individu, { id: 'basic' });
+
+            expect(_.size(individu.basic)).toEqual(13);
+            expect(_.size(_.filter(individu.basic, function(v) { return v === 0; }))).toEqual(13);
+        });
+
+        it('shouldn‘t amend the ressource if a value is provided for a period in the current year', function() {
+            var currentMonth = moment(dateDeValeur).format('YYYY-MM');
+            var individu = {
+                basic: {}
+            };
+            individu.basic[currentMonth] = 0;
+
+            var periodKeys = service.getPeriodKeysForCurrentYear(dateDeValeur, individu, { id: 'basic' });
+
+            expect(_.size(individu.basic)).toEqual(1);
+        });
+    });
+
     describe('unsetForCurrentYear', function() {
         it('should drop ressource', function() {
             individu.basic = {};


### PR DESCRIPTION
The logic to set default values was always settting the value for the current month to zero when missing therefore the checkox box was always checked on reload.

Now default values are set if there is no value provided for none of the periods.