### PR TITLE
App OpenFisca extension for Loiret county

### DIFF
--- a/backend/lib/ludwig/api-possible-values.js
+++ b/backend/lib/ludwig/api-possible-values.js
@@ -113,4 +113,8 @@ module.exports = [
         'shortLabel': 'Rennes - Transport',
         'unit': '%',
     },
+    {
+        'id': 'loiret_apa',
+        'shortLabel': 'Loiret - APA',
+    },
 ];

--- a/backend/lib/openfisca/mapping/common.js
+++ b/backend/lib/openfisca/mapping/common.js
@@ -55,8 +55,12 @@ function generateRequestedVariables() {
         });
     });
 
-    return _.chain(structuredVariables).flatten().flatten().value()
+    var requestedVariables = _.chain(structuredVariables).flatten().flatten().value()
         .reduce(function(obj, accum) { return _.assign(accum, obj); } , {});
+
+    requestedVariables.loiret_apa = {};
+
+    return requestedVariables;
 }
 
 exports.requestedVariables = generateRequestedVariables();

--- a/openfisca/api_config.ini
+++ b/openfisca/api_config.ini
@@ -12,9 +12,10 @@ use = egg:OpenFisca-Web-API
 country_package = openfisca_france
 log_level = DEBUG
 extensions =
+    openfisca_cd93
+    openfisca_loiret
     openfisca_paris
     openfisca_rennesmetropole
-    openfisca_cd93
 
 # Logging configuration
 [loggers]

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,6 +1,7 @@
 gunicorn>=19.1.1
 openfisca_web_api==6.2.2
 openfisca_france==18.9.2
-git+https://github.com/sgmap/openfisca-paris.git@28c3ee1a117f4b1822fddd379605ed2886bbd715#egg=openfisca-paris
 git+https://github.com/sgmap/openfisca-cd93.git@e9d62dd8705040e46ea075301116fa6d00925157#egg=openfisca-cd93
+git+https://github.com/sgmap/openfisca-loiret.git@1eeca31010308b07df21378790a0990a600f57c2#egg=openfisca-Loiret
+git+https://github.com/sgmap/openfisca-paris.git@28c3ee1a117f4b1822fddd379605ed2886bbd715#egg=openfisca-paris
 git+https://github.com/sgmap/openfisca-rennesmetropole.git@30c9cb9fc89f619e0f05decfae3ecb7bcc6bcf65#egg=openfisca-RennesMetropole


### PR DESCRIPTION
The `loiret_apa` from [openfisca-loiret](https://github.com/sgmap/openfisca-loiret) is requested and calculated.

However `loiret_apa` was not added to `droits.js` so it does not appear on the home page.