### PR TITLE
Personnalisation APA pour le CG93

### DIFF
--- a/app/js/constants/droits.js
+++ b/app/js/constants/droits.js
@@ -274,6 +274,7 @@ var droitsDescription = {
                             provider: {
                                 imgSrc: 'logo_cd93.png',
                             },
+                            instructions: undefined, // Prevent default instructions recycling
                             form: 'https://www.seine-saint-denis.fr/IMG/pdf/dossier_2.pdf',
                             link: 'https://www.seine-saint-denis.fr/ADPA.html',
                         },

--- a/app/js/constants/droits.js
+++ b/app/js/constants/droits.js
@@ -270,6 +270,13 @@ var droitsDescription = {
                             instructions: 'https://apa.paris.fr/portailAPA/',
                             link: 'https://www.paris.fr/aides_soutien_a_domicile#allocation-personnalisee-d-autonomie-a-domicile-apa_21',
                         },
+                        'D93-SSD': {
+                            provider: {
+                                imgSrc: 'logo_cd93.png',
+                            },
+                            form: 'https://www.seine-saint-denis.fr/IMG/pdf/dossier_2.pdf',
+                            link: 'https://www.seine-saint-denis.fr/ADPA.html',
+                        },
                     }
                 }
             }

--- a/app/js/constants/droits.js
+++ b/app/js/constants/droits.js
@@ -411,25 +411,6 @@ var droitsDescription = {
                 }
             }
         },
-        'cd93': {
-            'imgSrc': 'logo_cd93.png',
-            'label': 'Département de Seine-Saint-Denis',
-            'prefix': 'du',
-            'prestations': {
-                'adpa': {
-                    'isMontantAnnuel': false,
-                    'unit': '%',
-                    'legend': 'des frais de dépendance',
-                    'label': 'Allocation départementale personnalisée d’autonomie',
-                    'shortLabel': 'ADPA',
-                    'description': 'L’Allocation Départementale Personnalisée d’Autonomie (ADPA) permet de financer une partie des dépenses nécessaires à votre maintien à domicile ou de couvrir une partie des frais liés à votre accueil en établissement. Elle est versée aux personnes âgées de 60 ans ou plus en perte d’autonomie.',
-                    'conditions': [],
-                    'link': 'https://www.seine-saint-denis.fr/ADPA.html',
-                    'form': 'https://www.seine-saint-denis.fr/IMG/pdf/formulaire_demande_adpa_mai_2016_vdef.pdf',
-                    'isBaseRessourcesYearMoins2': false
-                },
-            }
-        },
         'rennes_metropole': {
             'imgSrc': 'logo_rennes_metropole.png',
             'label': 'Rennes Métropole',

--- a/app/js/controllers/foyer/individuForm.js
+++ b/app/js/controllers/foyer/individuForm.js
@@ -14,7 +14,7 @@ angular.module('ddsApp').controller('FoyerIndividuFormCtrl', function($scope, in
         $scope.capturePrenom = true;
 
         $scope.specificSituations = _.filter($scope.specificSituations, function(statut) {
-          return (statut.id !== 'retraite') && (statut.id !== 'perte_autonomie');
+          return (statut.id !== 'retraite');
         });
     }
 
@@ -82,7 +82,6 @@ angular.module('ddsApp').controller('FoyerIndividuFormCtrl', function($scope, in
         role: individuRole,
         tns_autres_revenus_type_activite: 'bic',
         tns_micro_entreprise_type_activite: 'bic',
-        perte_autonomie: false,
         tns_auto_entrepreneur_type_activite: 'bic',
         specificSituations: []
     };
@@ -135,8 +134,6 @@ angular.module('ddsApp').controller('FoyerIndividuFormCtrl', function($scope, in
             if (! $scope.captureScolarite(form)) {
                 delete $scope.individu.scolarite;
             }
-
-            $scope.individu.perte_autonomie = $scope.individu.gir == 'Gir 1';
 
             $scope.$emit('individu.' + individuRole, $scope.individu);
         }

--- a/backend/lib/ludwig/api-possible-values.js
+++ b/backend/lib/ludwig/api-possible-values.js
@@ -98,11 +98,6 @@ module.exports = [
         'shortLabel': 'CSP'
     },
     {
-        'id':'adpa',
-        'unit': '%',
-        'shortLabel':'ADPA',
-    },
-    {
         'id': 'aah',
         'shortLabel': 'AAH',
         'uncomputabilityReasons': {

--- a/backend/lib/migrations/initial.js
+++ b/backend/lib/migrations/initial.js
@@ -116,7 +116,6 @@ exports.migratePersistedSituation = function(sourceSituation) {
         id: 'id',
         microEntrepriseActiviteType: 'tns_micro_entreprise_type_activite',
         nationalite: 'nationalite',
-        perteAutonomie: 'perte_autonomie',
         place: 'enfant_place',
         role: 'role',
         specificSituations: 'specificSituations',

--- a/backend/lib/openfisca/mapping/last3MonthsDuplication.js
+++ b/backend/lib/openfisca/mapping/last3MonthsDuplication.js
@@ -23,7 +23,6 @@ var individuProperties = [
     'habite_chez_parents',
     'handicap',
     'inapte_travail',
-    'perte_autonomie',
     'scolarite',
     'statut_marital',
     'taux_incapacite',

--- a/backend/models/situation.js
+++ b/backend/models/situation.js
@@ -54,7 +54,6 @@ var individuDef = Object.assign({
     gir: { type: String, default: 'Non défini' },
     habite_chez_parents: Boolean,
     nationalite: { type: String, enum: ['fr', 'ue', 'autre'] },
-    perte_autonomie: Boolean,
     role: { type: String, enum: ['demandeur', 'conjoint', 'enfant'] },
     scolarite: { type: String, enum: ['Inconnue', 'Collège', 'Lycée'] },
     specificSituations: [{ type: String, enum: specificSituationValues }],

--- a/openfisca/api_config.ini
+++ b/openfisca/api_config.ini
@@ -12,7 +12,6 @@ use = egg:OpenFisca-Web-API
 country_package = openfisca_france
 log_level = DEBUG
 extensions =
-    openfisca_cd93
     openfisca_paris
     openfisca_rennesmetropole
 

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,6 +1,5 @@
 gunicorn>=19.1.1
 openfisca_web_api==6.2.2
 openfisca_france==18.10.0
-git+https://github.com/sgmap/openfisca-cd93.git@e9d62dd8705040e46ea075301116fa6d00925157#egg=openfisca-cd93
 git+https://github.com/sgmap/openfisca-paris.git@28c3ee1a117f4b1822fddd379605ed2886bbd715#egg=openfisca-paris
 git+https://github.com/sgmap/openfisca-rennesmetropole.git@30c9cb9fc89f619e0f05decfae3ecb7bcc6bcf65#egg=openfisca-RennesMetropole


### PR DESCRIPTION
Cette PR ajoute la personnalisation des liens de l'APA pour la Seine Saint Denis tout en retirant les références maintenant deprecated à l'ancien module d'ADPA.