### PR TITLE
Suppression numéro télédéclaration CNIL

### DIFF
--- a/app/views/content-pages/cgu.html
+++ b/app/views/content-pages/cgu.html
@@ -43,7 +43,6 @@
   </p>
   <p>
     Pour autant, une fois réunies, les données nécessaires pour évaluer vos droits (revenus, âge, code postal…) ont un caractère personnel. Nous en avons donc déclaré le traitement auprès de la <abbr title="Commission Nationale de l'Informatique et des Libertés">CNIL</abbr>.
-    <small>Le numéro de déclaration est 2004318v0.</small>
   </p>
   <p>
     Nous conservons ces données pendant deux ans à compter de la simulation pour analyser les usages, mesurer l'impact et la diffusion territoriale de Mes Aides, et améliorer le service.


### PR DESCRIPTION
En lien avec https://github.com/sgmap/mes-aides-ui/issues/731 .

De la confusion entre ce numéro et l'identifiant de la simulation. Ce numéro n'est pas obligatoire (cf https://www.cnil.fr/fr/cnil-direct/question/672 ). Cela retire de la confusion.