### PR TITLE
Update required period keys for tns_auto_entrepreneur_chiffre_affaires

### DIFF
--- a/app/js/services/ressourceService.js
+++ b/app/js/services/ressourceService.js
@@ -13,9 +13,10 @@ angular.module('ddsCommon').factory('RessourceService', function(MonthService, c
         if (ressourceType.id == 'tns_auto_entrepreneur_chiffre_affaires')
         {
             periodKeys.push(lastYear);
+            periodKeys = periodKeys.concat(_.map(MonthService.getMonths(dateDeValeur, 3), 'id'));
+        } else {
+            periodKeys = periodKeys.concat(_.map(MonthService.getMonths(dateDeValeur, 12), 'id'));
         }
-
-        periodKeys = periodKeys.concat(_.map(MonthService.getMonths(dateDeValeur, 12), 'id'));
 
         if (! ressourceType.revenuExceptionnel) {
             periodKeys.push(moment(dateDeValeur).format('YYYY-MM'));


### PR DESCRIPTION
For a situation as of 2017-12-31, requiring the last 12 months was generating a payload in this invalid section (invalid because "2017" value and the sum of monthly values are inconsistent):
```json
"tns_auto_entrepreneur_chiffre_affaires": {
    "2016": 625,
    "2017": 625,
    "2017-01": 0,
    "2017-02": 0,
    "2017-03": 0,
    "2017-04": 0,
    "2017-05": 0,
    "2017-06": 0,
    "2017-07": 0,
    "2017-08": 0,
    "2017-09": 0,
    "2017-10": 0,
    "2017-11": 0,
    "2017-12": 0
},
```

The correct section is
```json
"tns_auto_entrepreneur_chiffre_affaires": {
    "2016": 625,
    "2017": 625,
    "2017-09": 0,
    "2017-10": 0,
    "2017-11": 0,
    "2017-12": 0
},
```