### PR TITLE
Shortlabel Rennes Metropole - Transports

### DIFF
--- a/app/js/constants/droits.js
+++ b/app/js/constants/droits.js
@@ -461,7 +461,7 @@ var droitsDescription = {
                     'unit': '%',
                     'legend': 'de l’abonnement STAR',
                     'label': 'Tarification solidaire transports',
-                    'shortLabel': 'Transport',
+                    'shortLabel': 'Rennes Transport',
                     'description': 'La tarification solidaire est une réduction de 50 %, 85 % ou 100 % (gratuité) de l’abonnement mensuel du réseau de transports en commun Star. La réduction s’applique également au service Handistar. Elle est accordée aux familles de Rennes Métropole ayant de faibles ressources. La tarification est accordée à tous les membres du foyer.',
                     'link': 'http://metropole.rennes.fr/pratique/infos-demarches/deplacements-stationnement-voirie/tarification-solidaire-des-transports/',
                     'instructions': 'http://metropole.rennes.fr/pratique/infos-demarches/deplacements-stationnement-voirie/tarification-solidaire-des-transports/#c33081',


### PR DESCRIPTION
Mise à jour du shortlabel de Rennes Métropole - Tarification solidaire des transports afin d'éviter de futurs doublons.